### PR TITLE
Add stack parsing logic

### DIFF
--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -127,7 +127,7 @@ func parseFirstFunc(line string) string {
 	if idx := strings.LastIndex(line, "("); idx > 0 {
 		return line[:idx]
 	}
-	return line
+	panic(fmt.Sprintf("function calls missing parents: %q", line))
 }
 
 // parseGoStackHeader parses a stack header that looks like:
@@ -137,12 +137,12 @@ func parseGoStackHeader(line string) (goroutineID int, state string) {
 	line = strings.TrimSuffix(line, ":\n")
 	parts := strings.SplitN(line, " ", 3)
 	if len(parts) != 3 {
-		panic(fmt.Sprintf("unexpected stack header format: %v", line))
+		panic(fmt.Sprintf("unexpected stack header format: %q", line))
 	}
 
 	id, err := strconv.Atoi(parts[1])
 	if err != nil {
-		panic(fmt.Sprintf("failed to parse goroutine ID: %v", parts[1]))
+		panic(fmt.Sprintf("failed to parse goroutine ID: %v in line %q", parts[1], line))
 	}
 
 	state = strings.TrimSuffix(strings.TrimPrefix(parts[2], "["), "]")

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -39,7 +39,7 @@ func TestAll(t *testing.T) {
 	// We use a global channel so that the function below does not
 	// recieve any arguments, so we can test that parseFirstFunc works
 	// regardless of arguments on the stack.
-	_allDone := make(chan struct{})
+	_allDone = make(chan struct{})
 	defer close(_allDone)
 
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
This is very similar to the tchannel-go stack parsing:
https://github.com/uber/tchannel-go/blob/dev/testutils/goroutines/stacks.go

This just adds unit tests and improves the interface a little. This will
likely be an internal package unless we have usecases that need access
to the stack.