### PR TITLE
Create and test options for filtering stacks

### DIFF
--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -55,6 +55,11 @@ func (s Stack) Full() string {
 	return s.fullStack.String()
 }
 
+// FirstFunction returns the name of the first function on the stack.
+func (s Stack) FirstFunction() string {
+	return s.firstFunction
+}
+
 func (s Stack) String() string {
 	return fmt.Sprintf(
 		"Goroutine %v in state %v, with %v on top of the stack:\n%s",

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -66,7 +66,7 @@ func TestCurrent(t *testing.T) {
 	got := Current()
 	assert.NotZero(t, got.ID(), "Should get non-zero goroutine id")
 	assert.Equal(t, "running", got.State())
-	assert.Equal(t, "go.uber.org/gleek/internal/stack.getStackBuffer", got.firstFunction)
+	assert.Equal(t, "go.uber.org/gleek/internal/stack.getStackBuffer", got.FirstFunction())
 
 	wantFrames := []string{
 		"stack.getStackBuffer",

--- a/options.go
+++ b/options.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gleek
+
+import (
+	"strings"
+	"time"
+
+	"go.uber.org/gleek/internal/stack"
+)
+
+// Option lets users specify custom verifications.
+type Option interface {
+	apply(*opts)
+}
+
+// We retry up to 20 times if we can't find the goroutine that
+// we are looking for. In between each attempt, we will sleep for
+// a short while to let any running goroutines complete.
+const _defaultRetries = 20
+
+type opts struct {
+	filters    []func(stack.Stack) bool
+	maxRetries int
+	maxSleep   time.Duration
+}
+
+// optionFunc lets us easily write options without a custom type.
+type optionFunc func(*opts)
+
+func (f optionFunc) apply(opts *opts) { f(opts) }
+
+// IgnoreTopFunction ignores any goroutines where the specified function
+// is at the top of the stack. The function name should be fully qualified,
+// e.g., go.uber.org/gleek.IgnoreTopFunction
+func IgnoreTopFunction(f string) Option {
+	return addFilter(func(s stack.Stack) bool {
+		return s.FirstFunction() == f
+	})
+}
+
+func addFilter(f func(stack.Stack) bool) Option {
+	return optionFunc(func(opts *opts) {
+		opts.filters = append(opts.filters, f)
+	})
+}
+
+func buildOpts(options ...Option) *opts {
+	opts := &opts{
+		maxRetries: _defaultRetries,
+		maxSleep:   100 * time.Millisecond,
+	}
+	opts.filters = append(opts.filters, isTestStack, isSyscallStack)
+	for _, option := range options {
+		option.apply(opts)
+	}
+	return opts
+}
+
+func (vo *opts) filter(s stack.Stack) bool {
+	for _, filter := range vo.filters {
+		if filter(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (vo *opts) retry(i int) bool {
+	if i >= vo.maxRetries {
+		return false
+	}
+
+	d := time.Duration(int(time.Microsecond) << uint(i))
+	if d > vo.maxSleep {
+		d = vo.maxSleep
+	}
+	time.Sleep(d)
+	return true
+}
+
+// isTestStack is a default filter installed to automatically skip goroutines
+// that the testing package runs while the user's tests are running.
+func isTestStack(s stack.Stack) bool {
+	// Until go1.7, the main goroutine ran RunTests, which started
+	// the test in a separate goroutine and waited for that test goroutine
+	// to end by waiting on a channel.
+	// Since go1.7, a separate goroutine is started to wait for signals.
+	switch s.FirstFunction() {
+	case "testing.RunTests", "testing.(*T).Run":
+		// In pre1.7 and post-1.7, background goroutines started by the testing
+		// package are blocked waiting on a channel.
+		return strings.HasPrefix(s.State(), "chan receive")
+	}
+	return false
+}
+
+func isSyscallStack(s stack.Stack) bool {
+	// Typically runs in the background when code uses CGo:
+	// https://github.com/golang/go/issues/16714
+	return s.FirstFunction() == "runtime.goexit" && strings.HasPrefix(s.State(), "syscall")
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gleek
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/gleek/internal/stack"
+)
+
+func blockTill(started chan struct{}, done chan struct{}) {
+	close(started)
+	<-done
+}
+
+func TestOptionsFilters(t *testing.T) {
+	opts := buildOpts()
+	cur := stack.Current()
+	all := stack.All()
+
+	// At least one of these should be the same as current, the others should be filtered out.
+	for _, s := range all {
+		if s.ID() == cur.ID() {
+			require.False(t, opts.filter(s), "Current test running function should not be filtered")
+		} else {
+			require.True(t, opts.filter(s), "Default goroutines should be filtered: %v", s)
+		}
+	}
+
+	var (
+		started = make(chan struct{})
+		done    = make(chan struct{})
+	)
+	defer close(done)
+	go blockTill(started, done)
+	<-started
+
+	// Now the filters should find something that doesn't match a filter.
+	countUnfiltered := func() int {
+		var unmatched int
+		for _, s := range stack.All() {
+			if s.ID() == cur.ID() {
+				continue
+			}
+			if !opts.filter(s) {
+				unmatched++
+			}
+		}
+		return unmatched
+	}
+	require.Equal(t, 1, countUnfiltered(), "Expected blockTill goroutine to not match any filter")
+
+	// If we add an extra filter to ignore blockTill, it shouldn't match.
+	opts = buildOpts(IgnoreTopFunction("go.uber.org/gleek.blockTill"))
+	require.Zero(t, countUnfiltered(), "blockTill should be filtered out")
+}
+
+func TestOptionsRetry(t *testing.T) {
+	opts := buildOpts()
+	opts.maxRetries = 50 // initial attempt + 50 retries = 11
+	opts.maxSleep = time.Millisecond
+
+	for i := 0; i < 50; i++ {
+		assert.True(t, opts.retry(i), "Attempt %v/51 should allow retrying", i)
+	}
+	assert.False(t, opts.retry(51), "Attempt 51/51 should not allow retrying")
+	assert.False(t, opts.retry(52), "Attempt 52/51 should not allow retrying")
+}


### PR DESCRIPTION
The API for finding leaks accepts a list of functional options to filter
the stacks which should be considered as a leak.

Since background goroutines might not be complete yet, we'll need to
retry and the options have (currently private) ways to control the
retries including number of attempts and duration.