### PR TITLE
Add travis/codecov for pre-commit validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
     - vendor
 
 install:
-  - make install
+  - make install_deps
 
 script:
   - test -z "$TEST" || make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ go:
   #- 1.7
   #- 1.8
   - 1.9
+env:
+- TEST=yes
 
 matrix:
   include:
   - go: 1.9
-    env: NO_TEST=yes COVERAGE=yes LINT=yes
+    env: COVERAGE=yes LINT=yes
 
 cache:
   directories:
@@ -22,9 +24,9 @@ install:
   - make install
 
 script:
-  - test -n "$NO_TEST" || make test
+  - test -z "$TEST" || make test
   - test -z "$COVERAGE" || scripts/coverage.sh
-  - test -n "$LINT" || make install_lint lint
+  - test -z "$LINT" || make install_lint lint
 
 after_success:
   - test -z "$COVERAGE" || bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+sudo: false
+language: go
+go_import_path: go.uber.org/goleak
+
+go:
+  # TODO(prashant): Enable once we have fixed Linux issues with old versions.
+  #- 1.6
+  #- 1.7
+  #- 1.8
+  - 1.9
+
+matrix:
+  include:
+  - go: 1.9
+    env: NO_TEST=yes COVERAGE=yes LINT=yes
+
+cache:
+  directories:
+    - vendor
+
+install:
+  - make install
+
+script:
+  - test -n "$NO_TEST" || make test
+  - test -z "$COVERAGE" || scripts/coverage.sh
+  - test -n "$LINT" || make install_lint lint
+
+after_success:
+  - test -z "$COVERAGE" || bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ go:
   #- 1.6
   #- 1.7
   #- 1.8
-  - 1.9
+  - 1.9.2
 env:
 - TEST=yes
 
 matrix:
   include:
-  - go: 1.9
+  - go: 1.9.2
     env: COVERAGE=yes LINT=yes
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,6 @@ lint:
 	@echo "Checking lint..."
 	@$(foreach dir,$(PACKAGES),golint $(dir) 2>&1 | tee -a lint.log;)
 	@echo "Checking for unresolved FIXMEs..."
-	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
+	@git grep -i fixme | grep -v -e '^vendor/' -e '^Makefile' | tee -a lint.log
 	@[ ! -s lint.log ]
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build:
 	go build -i $(PACKAGES)
 
 
-.PHONY: install
-install:
+.PHONY: install_deps
+install_deps:
 	glide --version || go get github.com/Masterminds/glide
 	glide install
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+PACKAGES := $(shell glide nv)
+# Many Go tools take file globs or directories as arguments instead of packages.
+PACKAGE_FILES ?= *.go $(shell find internal -type f -iname '*.go')
+
+.PHONY: build
+build:
+	go build -i $(PACKAGES)
+
+
+.PHONY: install
+install:
+	glide --version || go get github.com/Masterminds/glide
+	glide install
+
+
+.PHONY: test
+test:
+	go test -v -race $(PACKAGES)
+
+.PHONY: install_lint
+install_lint:
+	go get github.com/golang/lint/golint
+
+.PHONY: lint
+lint:
+	@rm -rf lint.log
+	@echo "Checking formatting..."
+	@gofmt -d -s $(PACKAGE_FILES) 2>&1 | tee lint.log
+	@echo "Checking vet..."
+	@$(foreach dir,$(PACKAGE_FILES),go tool vet $(dir) 2>&1 | tee -a lint.log;)
+	@echo "Checking lint..."
+	@$(foreach dir,$(PACKAGES),golint $(dir) 2>&1 | tee -a lint.log;)
+	@echo "Checking for unresolved FIXMEs..."
+	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
+	@[ ! -s lint.log ]
+

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./...); do
+    go test -race -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
The coverage.sh is from codecov. Once 1.10 lands, we'll no longer need
it.

There are currently issues with < Go 1.9 on Linux which we will need to fix separately.