### PR TITLE
Indent a code example in a comment

### DIFF
--- a/testmain.go
+++ b/testmain.go
@@ -41,9 +41,9 @@ type TestingM interface {
 // verify that there were no goroutine leaks.
 // To use it, your TestMain function should look like:
 //
-// func TestMain(m *testing.M) {
-//   goleak.VerifyTestMain(m)
-// }
+//  func TestMain(m *testing.M) {
+//    goleak.VerifyTestMain(m)
+//  }
 //
 // This will run all tests as per normal, and if they were successful, look
 // for any goroutine leaks and fail the tests if any leaks were found.


### PR DESCRIPTION
Hi @prashantv 

Adding indentation to fix the rendering of the code example in the docs.

![generated-docs](https://user-images.githubusercontent.com/3024728/34932318-0d8a3e84-f9db-11e7-821b-fb429bf613e0.png)