### PR TITLE
Fix typo

### DIFF
--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -37,7 +37,7 @@ func waitForDone() {
 
 func TestAll(t *testing.T) {
 	// We use a global channel so that the function below does not
-	// recieve any arguments, so we can test that parseFirstFunc works
+	// receive any arguments, so we can test that parseFirstFunc works
 	// regardless of arguments on the stack.
 	_allDone = make(chan struct{})
 	defer close(_allDone)


### PR DESCRIPTION
Found with misspell on [Go Report Card](https://goreportcard.com/report/github.com/uber-go/goleak#misspell)