### PR TITLE
Using strings.HasSuffix so vendored projects can pass tests

### DIFF
--- a/options.go
+++ b/options.go
@@ -53,7 +53,7 @@ func (f optionFunc) apply(opts *opts) { f(opts) }
 // e.g., go.uber.org/goleak.IgnoreTopFunction
 func IgnoreTopFunction(f string) Option {
 	return addFilter(func(s stack.Stack) bool {
-		return s.FirstFunction() == f
+		return strings.HasSuffix(s.FirstFunction(), f)
 	})
 }
 


### PR DESCRIPTION
Vendored and non-vendored packages have different absolute paths but have the same ending.

eg.
`github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts`
and
`github.com/koshatul/testproject/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts`