### PR TITLE
Ignore t.Parallel goroutines, they represent queued tests

### DIFF
--- a/leaks_test.go
+++ b/leaks_test.go
@@ -82,3 +82,13 @@ func TestVerifyNoLeaks(t *testing.T) {
 	require.NotEmpty(t, ft.errors, "Expect errors from VerifyNoLeaks on leaked goroutine")
 	bg.unblock()
 }
+
+func TestVerifyParallel(t *testing.T) {
+	t.Run("parallel", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("serial", func(t *testing.T) {
+		VerifyNoLeaks(t)
+	})
+}

--- a/options.go
+++ b/options.go
@@ -114,6 +114,8 @@ func isTestStack(s stack.Stack) bool {
 	// the test in a separate goroutine and waited for that test goroutine
 	// to end by waiting on a channel.
 	// Since go1.7, a separate goroutine is started to wait for signals.
+	// T.Parallel is for parallel tests, which are blocked until all serial
+	// tests have run with T.Parallel at the top of the stack.
 	switch s.FirstFunction() {
 	case "testing.RunTests", "testing.(*T).Run", "testing.(*T).Parallel":
 		// In pre1.7 and post-1.7, background goroutines started by the testing

--- a/options.go
+++ b/options.go
@@ -115,7 +115,7 @@ func isTestStack(s stack.Stack) bool {
 	// to end by waiting on a channel.
 	// Since go1.7, a separate goroutine is started to wait for signals.
 	switch s.FirstFunction() {
-	case "testing.RunTests", "testing.(*T).Run":
+	case "testing.RunTests", "testing.(*T).Run", "testing.(*T).Parallel":
 		// In pre1.7 and post-1.7, background goroutines started by the testing
 		// package are blocked waiting on a channel.
 		return strings.HasPrefix(s.State(), "chan receive")


### PR DESCRIPTION
When t.Parallel is used, tests are queued to run after all serially
executed tests are run. This causes issues if the serial test tries to
verify goroutines.

Fixes #16