### PR TITLE
IgnoreMatch() Option

### DIFF
--- a/options.go
+++ b/options.go
@@ -57,6 +57,14 @@ func IgnoreTopFunction(f string) Option {
 	})
 }
 
+// IgnoreMatch ignores any goroutines where the specified match substring
+// is present in the stack grace.
+func IgnoreMatch(m string) Option {
+	return addFilter(func(s stack.Stack) bool {
+		return strings.Contains(s.Full(), m)
+	})
+}
+
 func maxSleep(d time.Duration) Option {
 	return optionFunc(func(opts *opts) {
 		opts.maxSleep = d

--- a/options_test.go
+++ b/options_test.go
@@ -63,7 +63,7 @@ func TestOptionsFilters(t *testing.T) {
 	// If we add an extra filter to ignore blockTill, it shouldn't match.
 	opts = buildOpts(IgnoreTopFunction("go.uber.org/goleak.(*blockedG).run"))
 	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", stack.All())
-	
+
 	// We should be able to add a match filter as well as a top-function one
 	opts = buildOpts(IgnoreMatch("go.uber.org/goleak.(*blockedG).run("))
 	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", stack.All())

--- a/options_test.go
+++ b/options_test.go
@@ -63,6 +63,10 @@ func TestOptionsFilters(t *testing.T) {
 	// If we add an extra filter to ignore blockTill, it shouldn't match.
 	opts = buildOpts(IgnoreTopFunction("go.uber.org/goleak.(*blockedG).run"))
 	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", stack.All())
+	
+	// We should be able to add a match filter as well as a top-function one
+	opts = buildOpts(IgnoreMatch("go.uber.org/goleak.(*blockedG).run("))
+	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", stack.All())
 }
 
 func TestOptionsRetry(t *testing.T) {


### PR DESCRIPTION
Option to ignore stack traces that have the full substring inside it.
(Can't be done in user-space because the opts struct is private.)