### PR TITLE
 Add latest versions to Travis, support 1.10+ only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,15 @@ go_import_path: go.uber.org/goleak
 
 go:
   # TODO(prashant): Enable once we have fixed Linux issues with old versions.
-  #- 1.6
-  #- 1.7
-  #- 1.8
-  - 1.9.2
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
 env:
 - TEST=yes
 
 matrix:
   include:
-  - go: 1.9.2
+  - go: 1.12.x
     env: COVERAGE=yes LINT=yes
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go_import_path: go.uber.org/goleak
 
 go:
-  # TODO(prashant): Enable once we have fixed Linux issues with old versions.
   - 1.10.x
   - 1.11.x
   - 1.12.x

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint:
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PACKAGE_FILES) 2>&1 | tee lint.log
 	@echo "Checking vet..."
-	@$(foreach dir,$(PACKAGE_FILES),go tool vet $(dir) 2>&1 | tee -a lint.log;)
+	@$(foreach dir,$(PACKAGE_FILES),go vet $(dir) 2>&1 | tee -a lint.log;)
 	@echo "Checking lint..."
 	@$(foreach dir,$(PACKAGES),golint $(dir) 2>&1 | tee -a lint.log;)
 	@echo "Checking for unresolved FIXMEs..."

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 
 .PHONY: install_lint
 install_lint:
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint:
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PACKAGE_FILES) 2>&1 | tee lint.log
 	@echo "Checking vet..."
-	@$(foreach dir,$(PACKAGE_FILES),go vet $(dir) 2>&1 | tee -a lint.log;)
+	@go vet $(PACKAGES) 2>&1 | tee -a lint.log
 	@echo "Checking lint..."
 	@$(foreach dir,$(PACKAGES),golint $(dir) 2>&1 | tee -a lint.log;)
 	@echo "Checking for unresolved FIXMEs..."

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -69,7 +69,7 @@ type fakeT struct {
 }
 
 func (ft *fakeT) Error(args ...interface{}) {
-	ft.errors = append(ft.errors, fmt.Sprint(args))
+	ft.errors = append(ft.errors, fmt.Sprint(args...))
 }
 
 func TestVerifyNone(t *testing.T) {


### PR DESCRIPTION
 * Fix golint + go vet to work with latest version
 * Fix correctly detected bug where `fmt.Sprint` was not used correctly.