### PR TITLE
Fix flaky tests

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -32,7 +32,7 @@ import (
 func TestOptionsFilters(t *testing.T) {
 	opts := buildOpts()
 	cur := stack.Current()
-	all := stack.All()
+	all := getStableAll(t, cur)
 
 	// At least one of these should be the same as current, the others should be filtered out.
 	for _, s := range all {


### PR DESCRIPTION
Some tests assume that stack.All() will give a stable set of goroutines:
that any background goroutines from the test framework/previous tests
have run till they're blocked.

Add verification that stack.All() returns a "stable" set of stacks
before running these tests.
