### PR TITLE
Ignore blocked trace stack by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ install:
 .PHONY: test
 test:
 	go test -v -race ./...
+	go test -v -trace=/dev/null .
 
 .PHONY: cover
 cover:

--- a/options.go
+++ b/options.go
@@ -78,6 +78,7 @@ func buildOpts(options ...Option) *opts {
 		isTestStack,
 		isSyscallStack,
 		isStdLibStack,
+		isTraceStack,
 	)
 	for _, option := range options {
 		option.apply(opts)
@@ -140,4 +141,12 @@ func isStdLibStack(s stack.Stack) bool {
 
 	// Using signal.Notify will start a runtime goroutine.
 	return strings.Contains(s.Full(), "runtime.ensureSigM")
+}
+
+func isTraceStack(s stack.Stack) bool {
+	if f := s.FirstFunction(); f != "runtime.goparkunlock" {
+		return false
+	}
+
+	return strings.Contains(s.Full(), "runtime.ReadTrace")
 }


### PR DESCRIPTION
When running tests with `-trace`, a background
goroutine blocks on `runtime.ReadTrace`:
```
Goroutine 20 in state trace reader (blocked), with runtime.goparkunlock on top of the stack:
goroutine 20 [trace reader (blocked)]:
runtime.goparkunlock(...)
	(truncated)/go1.13.linux.amd64/src/runtime/proc.go:310
runtime.ReadTrace(0xc00008e048, 0xc0000160d0, 0x10)
	(truncated)/go1.13.linux.amd64/src/runtime/trace.go:395 +0x4ed
runtime/trace.Start.func1(0x7b3dc0, 0xc00008e048)
	(truncated)/go1.13.linux.amd64/src/runtime/trace/trace.go:129 +0x47
created by runtime/trace.Start
	(truncated)/go1.13.linux.amd64/src/runtime/trace/trace.go:127 +0xd8
```

Skip this stack by default. Run tests with `-trace` enabled to verify
that this stack should be skipped.

Fixes #39.