### PR TITLE
Run tests on Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   include:
   - go: 1.12.x
   - go: 1.13.x
+  - go: 1.14.x
     env: LINT=1
 
 install:


### PR DESCRIPTION
This PR updates travis to run tests on Go 1.14 since the stable version is out.