### PR TITLE
Add Examples to failing tests check

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ go test -c -o tests
 
 # Run each test individually, printing "." for successful tests, or the test name
 # for failing tests.
-$ for test in $(go test -list . | grep "^Test"); do ./tests -test.run "^$test\$" &>/dev/null && echo -n "." || echo "\n$test failed"; done
+$ for test in $(go test -list . | grep -E "^(Test|Example)"); do ./tests -test.run "^$test\$" &>/dev/null && echo -n "." || echo "\n$test failed"; done
 ```
 
 This will only print names of failing tests which can be investigated individually. E.g.,


### PR DESCRIPTION
Hi there, thanks for the amazing tool!

I insert following code into one of my package test files:
```
func TestMain(m *testing.M) {
	goleak.VerifyTestMain(m)
}
```

Then on tests run:
```
$ go test -count=1 ./...
PASS
goleak: Errors on successful test run: found unexpected goroutines:
<...>
```

I've tried the following command to identify the problem:
```
# Create a test binary which will be used to run each test individually
$ go test -c -o tests

# Run each test individually, printing "." for successful tests, or the test name
# for failing tests.
$ for test in $(go test -list . | grep "^Test"); do ./tests -test.run "^$test\$" &>/dev/null && echo -n "." || echo "\n$test failed"; done
.....................................%      
```

And here is behavior after applying the adjusted command from this PR:

```
for test in $(go test -list . | grep -E "^(Test|Example)"); do ./tests -test.run "^$test\$" &>/dev/null && echo -n "." || echo "\n$test failed"; done
.....................................
ExampleLoadingCache_Get failed

ExampleLoadingCache_Delete failed
..%                            
```