### PR TITLE
Add option to pass teardown function

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -55,6 +55,11 @@ func Find(options ...Option) error {
 	cur := stack.Current().ID()
 
 	opts := buildOpts(options...)
+
+	if opts.teardown != nil {
+		opts.teardown()
+	}
+
 	var stacks []stack.Stack
 	retry := true
 	for i := 0; retry; i++ {

--- a/options.go
+++ b/options.go
@@ -39,6 +39,7 @@ const _defaultRetries = 20
 
 type opts struct {
 	filters    []func(stack.Stack) bool
+	teardown   func()
 	maxRetries int
 	maxSleep   time.Duration
 }
@@ -54,6 +55,13 @@ func (f optionFunc) apply(opts *opts) { f(opts) }
 func IgnoreTopFunction(f string) Option {
 	return addFilter(func(s stack.Stack) bool {
 		return s.FirstFunction() == f
+	})
+}
+
+// Teardown adds function that is executed after successful test pass and before leak check
+func Teardown(f func()) Option {
+	return optionFunc(func(opts *opts) {
+		opts.teardown = f
 	})
 }
 


### PR DESCRIPTION
Hi!

In some cases performing additional work after test execution are required. But when `VerifyTestMain` is used it is not possible to do this work before leaked goroutine caught. This may be related to goroutine shutdown, so it should be done inside `VerifyTestMain` after test run but before check.

This PR adds option to pass custom teardown function.
