### PR TITLE
Add option to ignore current goroutines

### DIFF
--- a/leaks_test.go
+++ b/leaks_test.go
@@ -87,6 +87,7 @@ func TestVerifyNone(t *testing.T) {
 func TestIgnoreCurrent(t *testing.T) {
 	t.Run("Should ignore current", func(t *testing.T) {
 		defer VerifyNone(t)
+
 		done := make(chan struct{})
 		go func() {
 			<-done

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -83,6 +83,16 @@ func TestVerifyNone(t *testing.T) {
 	bg.unblock()
 }
 
+func TestIgnoreCurrentStacks(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		<-done
+	}()
+	VerifyNone(t, IgnoreCurrentStacks())
+	close(done)
+	VerifyNone(t)
+}
+
 func TestVerifyParallel(t *testing.T) {
 	t.Run("parallel", func(t *testing.T) {
 		t.Parallel()

--- a/options.go
+++ b/options.go
@@ -57,9 +57,9 @@ func IgnoreTopFunction(f string) Option {
 	})
 }
 
-// IgnoreCurrentStacks remembers all current stacks and ignores them on verifying.
-// This Option may be used in big projects that recently started to use go-leak.
-func IgnoreCurrentStacks() Option {
+// IgnoreCurrent records all current goroutines when the option is created, and ignores
+// them in any future Find/Verify calls.
+func IgnoreCurrent() Option {
 	excludeIDSet := map[int]bool{}
 	for _, s := range stack.All() {
 		excludeIDSet[s.ID()] = true

--- a/options.go
+++ b/options.go
@@ -57,6 +57,18 @@ func IgnoreTopFunction(f string) Option {
 	})
 }
 
+// IgnoreCurrentStacks remembers all current stacks and ignores them on verifying.
+// This Option may be used in big projects that recently started to use go-leak.
+func IgnoreCurrentStacks() Option {
+	excludeIDSet := map[int]bool{}
+	for _, s := range stack.All() {
+		excludeIDSet[s.ID()] = true
+	}
+	return addFilter(func(s stack.Stack) bool {
+		return excludeIDSet[s.ID()]
+	})
+}
+
 func maxSleep(d time.Duration) Option {
 	return optionFunc(func(opts *opts) {
 		opts.maxSleep = d


### PR DESCRIPTION
This allows usage specific tests in big projects that recently started to use go-leak check.

Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>


## Motivation

https://github.com/uber-go/goleak/issues/48