### PR TITLE
CI: Test against Go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.14.x", "1.15.x", "1.16.x"]
+        go: ["1.14.x", "1.15.x", "1.16.x", "1.17.x"]
         include:
-        - go: 1.16.x
+        - go: 1.17.x
           latest: true
 
     steps:

--- a/signal_test.go
+++ b/signal_test.go
@@ -35,7 +35,7 @@ func TestNoLeaks(t *testing.T) {
 	require.NoError(t, goleak.Find(), "Found leaks caused by signal import")
 
 	// Register some signal handlers and ensure there's no leaks.
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	require.NoError(t, goleak.Find(), "Found leaks caused by signal.Notify")
 

--- a/tools_test.go
+++ b/tools_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// go:build tools
 // +build tools
 
 package goleak

--- a/tools_test.go
+++ b/tools_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// go:build tools
+//go:build tools
 // +build tools
 
 package goleak


### PR DESCRIPTION
Start testing against Go 1.17. 

Changes were also made to a couple of test files to make them pass the linters in Go 1.17