### PR TITLE
Fix isTraceStack on newer Go versions

### DIFF
--- a/options.go
+++ b/options.go
@@ -154,11 +154,3 @@ func isStdLibStack(s stack.Stack) bool {
 	// Using signal.Notify will start a runtime goroutine.
 	return strings.Contains(s.Full(), "runtime.ensureSigM")
 }
-
-func isTraceStack(s stack.Stack) bool {
-	if f := s.FirstFunction(); f != "runtime.goparkunlock" {
-		return false
-	}
-
-	return strings.Contains(s.Full(), "runtime.ReadTrace")
-}

--- a/tracestack_new.go
+++ b/tracestack_new.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build go1.16
+// +build go1.16
+
+package goleak
+
+import (
+	"strings"
+
+	"go.uber.org/goleak/internal/stack"
+)
+
+func isTraceStack(s stack.Stack) bool {
+	return strings.Contains(s.Full(), "runtime.ReadTrace")
+}

--- a/tracestack_old.go
+++ b/tracestack_old.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build !go1.16
+// +build !go1.16
+
+package goleak
+
+import (
+	"strings"
+
+	"go.uber.org/goleak/internal/stack"
+)
+
+func isTraceStack(s stack.Stack) bool {
+	if f := s.FirstFunction(); f != "runtime.goparkunlock" {
+		return false
+	}
+
+	return strings.Contains(s.Full(), "runtime.ReadTrace")
+}


### PR DESCRIPTION
This fixes #66 . 

On newer Go versions (1.16 onwards), the top of trace stacks is no longer `runtime.goparkunlock`. We had a logic that relied on this being the case, which made the tests to fail with `-trace` flag for newer Go versions. However, to maintain backwards compatibility, we shouldn't just remove this check.

This separates out the `isTraceStack` into a separate file that gets conditionally compiled on different Go versions (`tracestack_old.go` for Go 1.15 and before and `tracestack_new.go` for Go 1.16 and newer) to address this issue.

Internal Ref: GO-887.