### PR TITLE
Provide stub so apps using goleak can build unchanged with tinygo.

### DIFF
--- a/leaks_tinygo.go
+++ b/leaks_tinygo.go
@@ -18,58 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build !tinygo
-// +build !tinygo
+//go:build tinygo
+// +build tinygo
+
+// goleak uses parts of go that are not yet supported by tinygo.
+// This file provides a placeholder to allow programs using goleak
+// to compile unchanged with tinygo before such support arrives.
 
 package goleak
-
-import (
-	"fmt"
-
-	"go.uber.org/goleak/internal/stack"
-)
 
 // TestingT is the minimal subset of testing.TB that we use.
 type TestingT interface {
 	Error(...interface{})
-}
-
-// filterStacks will filter any stacks excluded by the given opts.
-// filterStacks modifies the passed in stacks slice.
-func filterStacks(stacks []stack.Stack, skipID int, opts *opts) []stack.Stack {
-	filtered := stacks[:0]
-	for _, stack := range stacks {
-		// Always skip the running goroutine.
-		if stack.ID() == skipID {
-			continue
-		}
-		// Run any default or user-specified filters.
-		if opts.filter(stack) {
-			continue
-		}
-		filtered = append(filtered, stack)
-	}
-	return filtered
-}
-
-// Find looks for extra goroutines, and returns a descriptive error if
-// any are found.
-func Find(options ...Option) error {
-	cur := stack.Current().ID()
-
-	opts := buildOpts(options...)
-	var stacks []stack.Stack
-	retry := true
-	for i := 0; retry; i++ {
-		stacks = filterStacks(stack.All(), cur, opts)
-
-		if len(stacks) == 0 {
-			return nil
-		}
-		retry = opts.retry(i)
-	}
-
-	return fmt.Errorf("found unexpected goroutines:\n%s", stacks)
 }
 
 // VerifyNone marks the given TestingT as failed if any extra goroutines are
@@ -77,7 +37,5 @@ func Find(options ...Option) error {
 // tests by doing:
 // 	defer VerifyNone(t)
 func VerifyNone(t TestingT, options ...Option) {
-	if err := Find(options...); err != nil {
-		t.Error(err)
-	}
+	// Stub until ported to tinygo
 }

--- a/testmain.go
+++ b/testmain.go
@@ -18,6 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build !tinygo
+// +build !tinygo
+
 package goleak
 
 import (


### PR DESCRIPTION
Tinygo can build a large subset of go programs already.
Unfortunately, tinygo currently does not quite support goleak.

As a temporary measure, use the tinygo build tag to provide a stub
for goleak.  This will expand the world of go programs that
run properly on tinygo, and remove one more obstacle keeping
embedded system and wasm users from adopting go and goleak.

This can be reverted if/when tinygo is enhanced to fully
support goleak.

Fixes https://github.com/uber-go/goleak/issues/71