### PR TITLE
Mark VerifyNone as a test Helper

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -69,12 +69,21 @@ func Find(options ...Option) error {
 	return fmt.Errorf("found unexpected goroutines:\n%s", stacks)
 }
 
+type testHelper interface {
+	Helper()
+}
+
 // VerifyNone marks the given TestingT as failed if any extra goroutines are
 // found by Find. This is a helper method to make it easier to integrate in
 // tests by doing:
 //
 //	defer VerifyNone(t)
 func VerifyNone(t TestingT, options ...Option) {
+	if h, ok := t.(testHelper); ok {
+		// Mark this function as a test helper, if available.
+		h.Helper()
+	}
+
 	if err := Find(options...); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Mark `VerifyNone(...)` as a test `Helper` function, so that it reports the error at the call site, rather than `leaks.go:78:`.

From the [go docs](https://pkg.go.dev/testing#T.Helper):
> Helper marks the calling function as a test helper function. When printing file and line information, that function will be skipped. Helper may be called simultaneously from multiple goroutines.

This is useful for tests that verify go routines at multiple points, so failures can be more easily distinguished.