### PR TITLE
Add Cleanup option

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -55,6 +55,9 @@ func Find(options ...Option) error {
 	cur := stack.Current().ID()
 
 	opts := buildOpts(options...)
+	if opts.teardown != nil {
+		return fmt.Errorf("Cleanup can only be passed to VerifyNone or VerifyTestMain")
+	}
 	var stacks []stack.Stack
 	retry := true
 	for i := 0; retry; i++ {
@@ -79,12 +82,17 @@ type testHelper interface {
 //
 //	defer VerifyNone(t)
 func VerifyNone(t TestingT, options ...Option) {
+	opts := buildOpts(options...)
 	if h, ok := t.(testHelper); ok {
 		// Mark this function as a test helper, if available.
 		h.Helper()
 	}
 
-	if err := Find(options...); err != nil {
+	if err := Find(opts); err != nil {
 		t.Error(err)
+	}
+
+	if opts.teardown != nil {
+		opts.teardown(0)
 	}
 }

--- a/leaks.go
+++ b/leaks.go
@@ -84,14 +84,14 @@ type testHelper interface {
 //	defer VerifyNone(t)
 func VerifyNone(t TestingT, options ...Option) {
 	opts := buildOpts(options...)
-	cleanup := opts.cleanup
+	var cleanup func(int)
+	cleanup, opts.cleanup = opts.cleanup, nil
+
 	if h, ok := t.(testHelper); ok {
 		// Mark this function as a test helper, if available.
 		h.Helper()
 	}
 
-	// Find does not appreciate cleanups
-	opts.cleanup = nil
 	if err := Find(opts); err != nil {
 		t.Error(err)
 	}

--- a/leaks.go
+++ b/leaks.go
@@ -21,6 +21,7 @@
 package goleak
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/goleak/internal/stack"
@@ -83,16 +84,19 @@ type testHelper interface {
 //	defer VerifyNone(t)
 func VerifyNone(t TestingT, options ...Option) {
 	opts := buildOpts(options...)
+	teardown := opts.teardown
 	if h, ok := t.(testHelper); ok {
 		// Mark this function as a test helper, if available.
 		h.Helper()
 	}
 
+	// Find does not appreciate teardowns
+	opts.teardown = nil
 	if err := Find(opts); err != nil {
 		t.Error(err)
 	}
 
-	if opts.teardown != nil {
-		opts.teardown(0)
+	if teardown != nil {
+		teardown(0)
 	}
 }

--- a/leaks.go
+++ b/leaks.go
@@ -56,7 +56,7 @@ func Find(options ...Option) error {
 	cur := stack.Current().ID()
 
 	opts := buildOpts(options...)
-	if opts.teardown != nil {
+	if opts.cleanup != nil {
 		return errors.New("Cleanup can only be passed to VerifyNone or VerifyTestMain")
 	}
 	var stacks []stack.Stack
@@ -84,19 +84,19 @@ type testHelper interface {
 //	defer VerifyNone(t)
 func VerifyNone(t TestingT, options ...Option) {
 	opts := buildOpts(options...)
-	teardown := opts.teardown
+	cleanup := opts.cleanup
 	if h, ok := t.(testHelper); ok {
 		// Mark this function as a test helper, if available.
 		h.Helper()
 	}
 
-	// Find does not appreciate teardowns
-	opts.teardown = nil
+	// Find does not appreciate cleanups
+	opts.cleanup = nil
 	if err := Find(opts); err != nil {
 		t.Error(err)
 	}
 
-	if teardown != nil {
-		teardown(0)
+	if cleanup != nil {
+		cleanup(0)
 	}
 }

--- a/leaks.go
+++ b/leaks.go
@@ -56,7 +56,7 @@ func Find(options ...Option) error {
 
 	opts := buildOpts(options...)
 	if opts.teardown != nil {
-		return fmt.Errorf("Cleanup can only be passed to VerifyNone or VerifyTestMain")
+		return errors.New("Cleanup can only be passed to VerifyNone or VerifyTestMain")
 	}
 	var stacks []stack.Stack
 	retry := true

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -51,6 +51,10 @@ func TestFind(t *testing.T) {
 	// Once we unblock the goroutine, we shouldn't have leaks.
 	bg.unblock()
 	require.NoError(t, Find(), "Should find no leaks by default")
+
+	// Find can't take in Cleanup option
+	err = Find(Cleanup(func(int) { assert.Fail(t, "this should not be called") }))
+	require.Error(t, err, "Should exit with invalid option")
 }
 
 func TestFindRetry(t *testing.T) {

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -86,6 +86,13 @@ func TestVerifyNone(t *testing.T) {
 	VerifyNone(ft, testOptions())
 	require.NotEmpty(t, ft.errors, "Expect errors from VerifyNone on leaked goroutine")
 	bg.unblock()
+
+	cleanupCalled := false
+	VerifyNone(ft, Cleanup(func(c int) {
+		assert.Equal(t, 0, c)
+		cleanupCalled = true
+	}))
+	require.True(t, cleanupCalled, "expect cleanup registered callback to be called")
 }
 
 func TestIgnoreCurrent(t *testing.T) {

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -40,21 +40,26 @@ func testOptions() Option {
 }
 
 func TestFind(t *testing.T) {
-	require.NoError(t, Find(), "Should find no leaks by default")
+	t.Run("Should find no leaks by default", func(t *testing.T) {
+		require.NoError(t, Find())
+	})
 
-	bg := startBlockedG()
-	err := Find(testOptions())
-	require.Error(t, err, "Should find leaks with leaked goroutine")
-	assert.Contains(t, err.Error(), "blockedG")
-	assert.Contains(t, err.Error(), "created by go.uber.org/goleak.startBlockedG")
+	t.Run("Find leaks with leaked goroutine", func(t *testing.T) {
+		bg := startBlockedG()
+		err := Find(testOptions())
+		require.Error(t, err, "Should find leaks with leaked goroutine")
+		assert.Contains(t, err.Error(), "blockedG")
+		assert.Contains(t, err.Error(), "created by go.uber.org/goleak.startBlockedG")
 
-	// Once we unblock the goroutine, we shouldn't have leaks.
-	bg.unblock()
-	require.NoError(t, Find(), "Should find no leaks by default")
+		// Once we unblock the goroutine, we shouldn't have leaks.
+		bg.unblock()
+		require.NoError(t, Find(), "Should find no leaks by default")
+	})
 
-	// Find can't take in Cleanup option
-	err = Find(Cleanup(func(int) { assert.Fail(t, "this should not be called") }))
-	require.Error(t, err, "Should exit with invalid option")
+	t.Run("Find can't take in Cleanup option", func(t *testing.T) {
+		err := Find(Cleanup(func(int) { assert.Fail(t, "this should not be called") }))
+		require.Error(t, err, "Should exit with invalid option")
+	})
 }
 
 func TestFindRetry(t *testing.T) {
@@ -78,21 +83,26 @@ func (ft *fakeT) Error(args ...interface{}) {
 }
 
 func TestVerifyNone(t *testing.T) {
-	ft := &fakeT{}
-	VerifyNone(ft)
-	require.Empty(t, ft.errors, "Expect no errors from VerifyNone")
+	t.Run("VerifyNone finds leaks", func(t *testing.T) {
+		ft := &fakeT{}
+		VerifyNone(ft)
+		require.Empty(t, ft.errors, "Expect no errors from VerifyNone")
 
-	bg := startBlockedG()
-	VerifyNone(ft, testOptions())
-	require.NotEmpty(t, ft.errors, "Expect errors from VerifyNone on leaked goroutine")
-	bg.unblock()
+		bg := startBlockedG()
+		VerifyNone(ft, testOptions())
+		require.NotEmpty(t, ft.errors, "Expect errors from VerifyNone on leaked goroutine")
+		bg.unblock()
+	})
 
-	cleanupCalled := false
-	VerifyNone(ft, Cleanup(func(c int) {
-		assert.Equal(t, 0, c)
-		cleanupCalled = true
-	}))
-	require.True(t, cleanupCalled, "expect cleanup registered callback to be called")
+	t.Run("cleanup registered callback should be called", func(t *testing.T) {
+		ft := &fakeT{}
+		cleanupCalled := false
+		VerifyNone(ft, Cleanup(func(c int) {
+			assert.Equal(t, 0, c)
+			cleanupCalled = true
+		}))
+		require.True(t, cleanupCalled, "expect cleanup registered callback to be called")
+	})
 }
 
 func TestIgnoreCurrent(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -41,6 +41,16 @@ type opts struct {
 	filters    []func(stack.Stack) bool
 	maxRetries int
 	maxSleep   time.Duration
+	teardown   func(int)
+}
+
+// implement apply so that opts struct itself can be used as
+// an Option.
+func (o opts) apply(opts *opts) {
+	opts.filters = o.filters
+	opts.maxRetries = o.maxRetries
+	opts.maxSleep = o.maxSleep
+	opts.teardown = o.teardown
 }
 
 // optionFunc lets us easily write options without a custom type.
@@ -54,6 +64,18 @@ func (f optionFunc) apply(opts *opts) { f(opts) }
 func IgnoreTopFunction(f string) Option {
 	return addFilter(func(s stack.Stack) bool {
 		return s.FirstFunction() == f
+	})
+}
+
+// Cleanup sets up a cleanup function that will be executed at the
+// end of the leak.
+// When passed to [VerifyTestMain], the exit code passed to cleanupFunc
+// will be set to the exit code of TestMain.
+// When passed to [VerifyNone], the exit code will be set to 0.
+// This cannot be passed to [Find].
+func Cleanup(cleanupFunc func(exitCode int)) Option {
+	return optionFunc(func(opts *opts) {
+		opts.teardown = cleanupFunc
 	})
 }
 
@@ -98,8 +120,8 @@ func buildOpts(options ...Option) *opts {
 	return opts
 }
 
-func (vo *opts) filter(s stack.Stack) bool {
-	for _, filter := range vo.filters {
+func (o *opts) filter(s stack.Stack) bool {
+	for _, filter := range o.filters {
 		if filter(s) {
 			return true
 		}
@@ -107,14 +129,14 @@ func (vo *opts) filter(s stack.Stack) bool {
 	return false
 }
 
-func (vo *opts) retry(i int) bool {
-	if i >= vo.maxRetries {
+func (o *opts) retry(i int) bool {
+	if i >= o.maxRetries {
 		return false
 	}
 
 	d := time.Duration(int(time.Microsecond) << uint(i))
-	if d > vo.maxSleep {
-		d = vo.maxSleep
+	if d > o.maxSleep {
+		d = o.maxSleep
 	}
 	time.Sleep(d)
 	return true

--- a/options.go
+++ b/options.go
@@ -46,7 +46,7 @@ type opts struct {
 
 // implement apply so that opts struct itself can be used as
 // an Option.
-func (o opts) apply(opts *opts) {
+func (o *opts) apply(opts *opts) {
 	opts.filters = o.filters
 	opts.maxRetries = o.maxRetries
 	opts.maxSleep = o.maxSleep
@@ -68,7 +68,7 @@ func IgnoreTopFunction(f string) Option {
 }
 
 // Cleanup sets up a cleanup function that will be executed at the
-// end of the leak.
+// end of the leak check.
 // When passed to [VerifyTestMain], the exit code passed to cleanupFunc
 // will be set to the exit code of TestMain.
 // When passed to [VerifyNone], the exit code will be set to 0.

--- a/options.go
+++ b/options.go
@@ -41,7 +41,7 @@ type opts struct {
 	filters    []func(stack.Stack) bool
 	maxRetries int
 	maxSleep   time.Duration
-	teardown   func(int)
+	cleanup    func(int)
 }
 
 // implement apply so that opts struct itself can be used as
@@ -50,7 +50,7 @@ func (o *opts) apply(opts *opts) {
 	opts.filters = o.filters
 	opts.maxRetries = o.maxRetries
 	opts.maxSleep = o.maxSleep
-	opts.teardown = o.teardown
+	opts.cleanup = o.cleanup
 }
 
 // optionFunc lets us easily write options without a custom type.
@@ -75,7 +75,7 @@ func IgnoreTopFunction(f string) Option {
 // This cannot be passed to [Find].
 func Cleanup(cleanupFunc func(exitCode int)) Option {
 	return optionFunc(func(opts *opts) {
-		opts.teardown = cleanupFunc
+		opts.cleanup = cleanupFunc
 	})
 }
 

--- a/testmain.go
+++ b/testmain.go
@@ -52,18 +52,18 @@ type TestingM interface {
 func VerifyTestMain(m TestingM, options ...Option) {
 	exitCode := m.Run()
 	opts := buildOpts(options...)
-	teardown := opts.teardown
+	cleanup := opts.cleanup
 
 	if exitCode == 0 {
-		// Find does not appreciate teardowns
-		opts.teardown = nil
+		// Find does not appreciate cleanup option.
+		opts.cleanup = nil
 		if err := Find(opts); err != nil {
 			fmt.Fprintf(_osStderr, "goleak: Errors on successful test run: %v\n", err)
 			exitCode = 1
 		}
 	}
-	if teardown != nil {
-		teardown(exitCode)
+	if cleanup != nil {
+		cleanup(exitCode)
 	} else {
 		_osExit(exitCode)
 	}

--- a/testmain.go
+++ b/testmain.go
@@ -52,15 +52,18 @@ type TestingM interface {
 func VerifyTestMain(m TestingM, options ...Option) {
 	exitCode := m.Run()
 	opts := buildOpts(options...)
+	teardown := opts.teardown
 
 	if exitCode == 0 {
+		// Find does not appreciate teardowns
+		opts.teardown = nil
 		if err := Find(opts); err != nil {
 			fmt.Fprintf(_osStderr, "goleak: Errors on successful test run: %v\n", err)
 			exitCode = 1
 		}
 	}
-	if opts.teardown != nil {
-		opts.teardown(exitCode)
+	if teardown != nil {
+		teardown(exitCode)
 	} else {
 		_osExit(exitCode)
 	}

--- a/testmain.go
+++ b/testmain.go
@@ -62,8 +62,6 @@ func VerifyTestMain(m TestingM, options ...Option) {
 	defer func() { cleanup(exitCode) }()
 
 	if exitCode == 0 {
-		// Find does not appreciate cleanup option.
-		opts.cleanup = nil
 		if err := Find(opts); err != nil {
 			fmt.Fprintf(_osStderr, "goleak: Errors on successful test run: %v\n", err)
 			exitCode = 1

--- a/testmain.go
+++ b/testmain.go
@@ -52,13 +52,12 @@ type TestingM interface {
 func VerifyTestMain(m TestingM, options ...Option) {
 	exitCode := m.Run()
 	opts := buildOpts(options...)
+
 	var cleanup func(int)
 	cleanup, opts.cleanup = opts.cleanup, nil
-
 	if cleanup == nil {
 		cleanup = _osExit
 	}
-
 	defer func() { cleanup(exitCode) }()
 
 	if exitCode == 0 {

--- a/testmain.go
+++ b/testmain.go
@@ -51,13 +51,17 @@ type TestingM interface {
 // for any goroutine leaks and fail the tests if any leaks were found.
 func VerifyTestMain(m TestingM, options ...Option) {
 	exitCode := m.Run()
+	opts := buildOpts(options...)
 
 	if exitCode == 0 {
-		if err := Find(options...); err != nil {
+		if err := Find(opts); err != nil {
 			fmt.Fprintf(_osStderr, "goleak: Errors on successful test run: %v\n", err)
 			exitCode = 1
 		}
 	}
-
-	_osExit(exitCode)
+	if opts.teardown != nil {
+		opts.teardown(exitCode)
+	} else {
+		_osExit(exitCode)
+	}
 }

--- a/testmain_test.go
+++ b/testmain_test.go
@@ -75,4 +75,13 @@ func TestVerifyTestMain(t *testing.T) {
 	VerifyTestMain(dummyTestMain(0))
 	assert.Equal(t, 0, <-exitCode, "Expect no errors without leaks")
 	assert.NotContains(t, <-stderr, "goleak: Errors", "No errors on successful run without leaks")
+
+	cleanupCalled := false
+	cleanupExitcode := 0
+	VerifyTestMain(dummyTestMain(3), Cleanup(func(ec int) {
+		cleanupCalled = true
+		cleanupExitcode = ec
+	}))
+	assert.True(t, cleanupCalled)
+	assert.Equal(t, 3, cleanupExitcode)
 }


### PR DESCRIPTION
This adds Cleanup option which can be passed to VerifyTestMain and
VerifyNone. This takes in a function that will be executed at the
end of the leak verification.

Internal Ref: GO-888
Fix #63 