### PR TITLE
Upgrade GitHub actions packages to resolve NodeJS 12 warnings

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository_owner == 'uber-go'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: FOSSA analysis
         uses: fossas/fossa-action@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Load cached dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Upgrades actions/checkout, actions/setup-go, and actions/cache to v3 to resolve CI warnings for NodeJS 12 deprecation.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Austin Vazquez <macedonv@amazon.com>