### PR TITLE
Remove mentions of Go 1.5 compatibility from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ You can use `go get` to get the latest version:
 
 `go get -u go.uber.org/goleak`
 
-`goleak` also supports semver releases. It is compatible with Go 1.5+.
+`goleak` also supports semver releases.
+
+Note that go-leak only [supports][release] the two most recent minor versions of Go.
 
 ## Quick Start
 
@@ -69,3 +71,4 @@ No breaking changes will be made to exported APIs before 2.0.
 [ci]: https://github.com/uber-go/goleak/actions/workflows/go.yml
 [cov-img]: https://codecov.io/gh/uber-go/goleak/branch/master/graph/badge.svg
 [cov]: https://codecov.io/gh/uber-go/goleak
+[release]: https://go.dev/doc/devel/release#policy


### PR DESCRIPTION
Fixes #85

We're no longer compatible with pre 1.16  since #79.

I'm opting for removing the version rather than updating it to 1.18 since we already have go.mod for this. 

Adding a pointer to the Go release policy, but I also considered dropping the mentions altogether. Copied the copy from `zap`.