### PR TITLE
Make maxSleep and maxRetires configurable when building options

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -56,6 +56,9 @@ func Find(options ...Option) error {
 	cur := stack.Current().ID()
 
 	opts := buildOpts(options...)
+	if err := opts.validate(); err != nil {
+		return err
+	}
 	if opts.cleanup != nil {
 		return errors.New("Cleanup can only be passed to VerifyNone or VerifyTestMain")
 	}

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -36,7 +36,7 @@ var _ = TestingT(testing.TB(nil))
 // testOptions passes a shorter max sleep time, used so tests don't wait
 // ~1 second in cases where we expect Find to error out.
 func testOptions() Option {
-	return MaxSleep(time.Millisecond)
+	return MaxSleepInterval(time.Millisecond)
 }
 
 func TestFind(t *testing.T) {
@@ -62,12 +62,12 @@ func TestFind(t *testing.T) {
 	})
 
 	t.Run("Find should return error when maxRetries is less than 0", func(t *testing.T) {
-		err := Find(MaxRetries(-1))
+		err := Find(MaxRetryAttempts(-1))
 		require.Error(t, err, "maxRetries should be greater than 0")
 	})
 
 	t.Run("Find should return error when maxSleep is less than 0s", func(t *testing.T) {
-		err := Find(MaxSleep(time.Duration(-1)))
+		err := Find(MaxSleepInterval(time.Duration(-1)))
 		require.Error(t, err, "maxSleep should be greater than 0s")
 	})
 }

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -36,7 +36,7 @@ var _ = TestingT(testing.TB(nil))
 // testOptions passes a shorter max sleep time, used so tests don't wait
 // ~1 second in cases where we expect Find to error out.
 func testOptions() Option {
-	return maxSleep(time.Millisecond)
+	return MaxSleep(time.Millisecond)
 }
 
 func TestFind(t *testing.T) {
@@ -59,6 +59,16 @@ func TestFind(t *testing.T) {
 	t.Run("Find can't take in Cleanup option", func(t *testing.T) {
 		err := Find(Cleanup(func(int) { assert.Fail(t, "this should not be called") }))
 		require.Error(t, err, "Should exit with invalid option")
+	})
+
+	t.Run("Find should return error when maxRetries is less than 0", func(t *testing.T) {
+		err := Find(MaxRetries(-1))
+		require.Error(t, err, "maxRetries should be greater than 0")
+	})
+
+	t.Run("Find should return error when maxSleep is less than 0s", func(t *testing.T) {
+		err := Find(MaxSleep(time.Duration(-1)))
+		require.Error(t, err, "maxSleep should be greater than 0s")
 	})
 }
 

--- a/options.go
+++ b/options.go
@@ -63,7 +63,7 @@ func (o *opts) validate() error {
 	if o.maxRetries < 0 {
 		return errors.New("maxRetryAttempts should be greater than 0")
 	}
-	if o.maxSleep < time.Duration(0) {
+	if o.maxSleep <= 0 {
 		return errors.New("maxSleepInterval should be greater than 0s")
 	}
 	return nil
@@ -108,7 +108,7 @@ func IgnoreCurrent() Option {
 }
 
 // MaxSleepInterval sets the maximum sleep time in-between each retry attempt.
-// The sleep duration is growing in an exponential backoff but limits to the value we set.
+// The sleep duration grows in an exponential backoff, to a maximum of the value specified here.
 // If not configured, default to 100 microseconds.
 func MaxSleepInterval(d time.Duration) Option {
 	return optionFunc(func(opts *opts) {

--- a/options_test.go
+++ b/options_test.go
@@ -68,17 +68,17 @@ func TestOptionsFilters(t *testing.T) {
 func TestBuildOptions(t *testing.T) {
 	// With default options.
 	opts := buildOpts()
-	assert.Equal(t, _defaultSleepTime, opts.maxSleep, "value of maxSleep not right")
-	assert.Equal(t, _defaultRetries, opts.maxRetries, "value of maxRetries not right")
+	assert.Equal(t, _defaultSleepInterval, opts.maxSleep, "value of maxSleep not right")
+	assert.Equal(t, _defaultRetryAttempts, opts.maxRetries, "value of maxRetries not right")
 
 	// With customized options.
-	opts = buildOpts(MaxRetries(50), MaxSleep(time.Microsecond))
+	opts = buildOpts(MaxRetryAttempts(50), MaxSleepInterval(time.Microsecond))
 	assert.Equal(t, time.Microsecond, opts.maxSleep, "value of maxSleep not right")
 	assert.Equal(t, 50, opts.maxRetries, "value of maxRetries not right")
 }
 
 func TestOptionsRetry(t *testing.T) {
-	opts := buildOpts(MaxSleep(time.Millisecond), MaxRetries(50)) // initial attempt + 50 retries = 51
+	opts := buildOpts(MaxSleepInterval(time.Millisecond), MaxRetryAttempts(50)) // initial attempt + 50 retries = 51
 
 	for i := 0; i < 50; i++ {
 		assert.True(t, opts.retry(i), "Attempt %v/51 should allow retrying", i)

--- a/options_test.go
+++ b/options_test.go
@@ -65,10 +65,20 @@ func TestOptionsFilters(t *testing.T) {
 	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", stack.All())
 }
 
-func TestOptionsRetry(t *testing.T) {
+func TestBuildOptions(t *testing.T) {
+	// With default options.
 	opts := buildOpts()
-	opts.maxRetries = 50 // initial attempt + 50 retries = 11
-	opts.maxSleep = time.Millisecond
+	assert.Equal(t, _defaultSleepTime, opts.maxSleep, "value of maxSleep not right")
+	assert.Equal(t, _defaultRetries, opts.maxRetries, "value of maxRetries not right")
+
+	// With customized options.
+	opts = buildOpts(MaxRetries(50), MaxSleep(time.Microsecond))
+	assert.Equal(t, time.Microsecond, opts.maxSleep, "value of maxSleep not right")
+	assert.Equal(t, 50, opts.maxRetries, "value of maxRetries not right")
+}
+
+func TestOptionsRetry(t *testing.T) {
+	opts := buildOpts(MaxSleep(time.Millisecond), MaxRetries(50)) // initial attempt + 50 retries = 51
 
 	for i := 0; i < 50; i++ {
 		assert.True(t, opts.retry(i), "Attempt %v/51 should allow retrying", i)


### PR DESCRIPTION
Make goleak options more flexible to adapt to users' variety scenarios

Signed-off-by: Kante Yin <kerthcet@gmail.com>

fix  https://github.com/uber-go/goleak/issues/93