### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.1]
+### Changed
+- Drop golang/x/lint dependency.
+
+[1.2.1]: https://github.com/uber-go/goleak/compare/v1.2.0...v1.2.1
+
 ## [1.2.0]
 ### Added
 - Add Cleanup option that can be used for registering cleanup callbacks. (#78)


### PR DESCRIPTION
This release is a patch release that removes golang/x/lint dependency.

Ref #99.