### PR TITLE
Ignore testing.runFuzzing and testing.runFuzzTests

### DIFF
--- a/options.go
+++ b/options.go
@@ -181,8 +181,12 @@ func isTestStack(s stack.Stack) bool {
 	// Since go1.7, a separate goroutine is started to wait for signals.
 	// T.Parallel is for parallel tests, which are blocked until all serial
 	// tests have run with T.Parallel at the top of the stack.
+	// testing.runFuzzTests is for fuzz testing, it's blocked until the test
+	// function with all seed corpus have run.
+	// testing.runFuzzing is for fuzz testing, it's blocked until a failing
+	// input is found.
 	switch s.FirstFunction() {
-	case "testing.RunTests", "testing.(*T).Run", "testing.(*T).Parallel":
+	case "testing.RunTests", "testing.(*T).Run", "testing.(*T).Parallel", "testing.runFuzzing", "testing.runFuzzTests":
 		// In pre1.7 and post-1.7, background goroutines started by the testing
 		// package are blocked waiting on a channel.
 		return strings.HasPrefix(s.State(), "chan receive")


### PR DESCRIPTION
When Fuzz testing, if the `-fuzz` flag is used then the fuzzing engine is used to generate test cases out of the seed corpus, this causes `testing.runFuzzTests` to be blocked until a failing input is found or there is a signal to stop generating.
On the other hand `testing.runFuzzTests` is called even without the use of the `-fuzz` flag, executes the input testing with all the elements in the seed corpus and it's blocked until every test has run.

On both cases, goleak detects them as leaking goroutines, but this are expected goroutines.

Internal Ref: GO-2002
Fix #104