### PR TITLE
add teardown option and create a unit test for it

### DIFF
--- a/options.go
+++ b/options.go
@@ -47,6 +47,7 @@ type opts struct {
 	maxRetries int
 	maxSleep   time.Duration
 	cleanup    func(int)
+	teardown   func()
 }
 
 // implement apply so that opts struct itself can be used as
@@ -56,6 +57,7 @@ func (o *opts) apply(opts *opts) {
 	opts.maxRetries = o.maxRetries
 	opts.maxSleep = o.maxSleep
 	opts.cleanup = o.cleanup
+	opts.teardown = o.teardown
 }
 
 // validate the options.
@@ -92,6 +94,18 @@ func IgnoreTopFunction(f string) Option {
 func Cleanup(cleanupFunc func(exitCode int)) Option {
 	return optionFunc(func(opts *opts) {
 		opts.cleanup = cleanupFunc
+	})
+}
+
+// Teardown sets up a teardown function that will be executed at the
+// end of the leak check.
+// When passed to [VerifyTestMain], the teardown function will be executed
+// before [Find].
+// The teardown function may be used to cancel goroutines after
+// all tests have completed.
+func Teardown(teardownFunc func()) Option {
+	return optionFunc(func(opts *opts) {
+		opts.teardown = teardownFunc
 	})
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -86,3 +86,10 @@ func TestOptionsRetry(t *testing.T) {
 	assert.False(t, opts.retry(51), "Attempt 51/51 should not allow retrying")
 	assert.False(t, opts.retry(52), "Attempt 52/51 should not allow retrying")
 }
+
+func TestOptionsTeardown(t *testing.T) {
+	ch := make(chan int, 1)
+	opts := buildOpts(Teardown(func() { ch <- 99; close(ch) }))
+	opts.teardown()
+	assert.Equal(t, 99, <-ch, "Teardown not writing to channel.")
+}

--- a/testmain.go
+++ b/testmain.go
@@ -53,6 +53,12 @@ func VerifyTestMain(m TestingM, options ...Option) {
 	exitCode := m.Run()
 	opts := buildOpts(options...)
 
+	var teardown func()
+	teardown, opts.teardown = opts.teardown, nil
+	if teardown != nil {
+		teardown()
+	}
+
 	var cleanup func(int)
 	cleanup, opts.cleanup = opts.cleanup, nil
 	if cleanup == nil {


### PR DESCRIPTION
It would be useful to be able to run a teardown function in VerifyTestMain that could stop any goroutines that would otherwise have to be stopped in each testcase. For example, in the [go-cache library](https://github.com/patrickmn/go-cache/tree/master), there is a [janitor function](https://github.com/patrickmn/go-cache/blob/46f407853014144407b6c2ec7ccc76bf67958d93/cache.go#L1093) that must be stopped explicitly by the user but if go-cache is used implicitly in a test package, then every testcase needs to stop the janitor function. With a teardown function, the hanging goroutine could be cancelled after all tests are run. 