### PR TITLE
Document incompatibility of VerifyNone with t.Parallel

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -85,6 +85,12 @@ type testHelper interface {
 // tests by doing:
 //
 //	defer VerifyNone(t)
+//
+// VerifyNone is currently incompatible with t.Parallel because it cannot
+// associate specific goroutines with specific tests. Thus, non-leaking 
+// goroutines from other tests running in parallel could fail this check.
+// If you need to run tests in parallel, use [VerifyTestMain] instead,
+// which will verify that no leaking goroutines exist after ALL tests finish.
 func VerifyNone(t TestingT, options ...Option) {
 	opts := buildOpts(options...)
 	var cleanup func(int)

--- a/leaks.go
+++ b/leaks.go
@@ -87,7 +87,7 @@ type testHelper interface {
 //	defer VerifyNone(t)
 //
 // VerifyNone is currently incompatible with t.Parallel because it cannot
-// associate specific goroutines with specific tests. Thus, non-leaking 
+// associate specific goroutines with specific tests. Thus, non-leaking
 // goroutines from other tests running in parallel could fail this check.
 // If you need to run tests in parallel, use [VerifyTestMain] instead,
 // which will verify that no leaking goroutines exist after ALL tests finish.


### PR DESCRIPTION
It's a known issue that goleak is incompatible with tests being run in parallel.
* https://github.com/uber-go/goleak/issues/16
* https://github.com/uber-go/goleak/issues/83

Unfortunately, there is no real solution to this issue.
* https://github.com/uber-go/goleak/issues/16#issuecomment-575020250
* https://github.com/uber-go/goleak/issues/83#issuecomment-1487300420
* https://github.com/uber-go/goleak/issues/83#issuecomment-1755316283

This PR at least documents the incompatibility
and suggests using `VerifyTestMain` instead.