### PR TITLE
stack: Parse all functions

### DIFF
--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -141,10 +141,6 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 	funcs := make(map[string]struct{})
 	for p.scan.Scan() {
 		line := p.scan.Text()
-		if len(line) == 0 {
-			continue
-		}
-
 		if strings.HasPrefix(line, "goroutine ") {
 			// If we see the goroutine header,
 			// it's the end of this stack.
@@ -155,6 +151,10 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 
 		fullStack.WriteString(line)
 		fullStack.WriteByte('\n') // scanner trims the newline
+
+		if len(line) == 0 {
+			continue
+		}
 
 		funcName, err := parseFuncName(line)
 		if err != nil {
@@ -174,6 +174,8 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 		if p.scan.Scan() {
 			bs := p.scan.Bytes()
 			if len(bs) > 0 && bs[0] == '\t' {
+				fullStack.Write(bs)
+				fullStack.WriteByte('\n')
 				continue
 			}
 

--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -165,13 +165,14 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 			firstFunction = funcName
 		}
 
-		// The function name is usually followed by a line in the form:
+		// The function name followed by a line in the form:
 		//
 		//	<tab>example.com/path/to/package/file.go:123 +0x123
 		//
-		// We don't care about the position, so we'll skip it,
-		// but only if it matches the expected format.
+		// We don't care about the position so we can skip this line.
 		if p.scan.Scan() {
+			// Be defensive:
+			// Skip the line only if it starts with a tab.
 			bs := p.scan.Bytes()
 			if len(bs) > 0 && bs[0] == '\t' {
 				fullStack.Write(bs)
@@ -179,7 +180,8 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 				continue
 			}
 
-			// Put it back if it doesn't match.
+			// Put it back and let the next iteration handle it
+			// if it doesn't start with a tab.
 			p.scan.Unscan()
 		}
 	}

--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -215,6 +215,7 @@ func getStackBuffer(all bool) []byte {
 //
 //	example.com/path/to/package.funcName(args...)
 //	example.com/path/to/package.(*typeName).funcName(args...)
+//	created by example.com/path/to/package.funcName
 //	created by example.com/path/to/package.funcName in goroutine [...]
 func parseFuncName(line string) (string, error) {
 	var name string
@@ -223,8 +224,9 @@ func parseFuncName(line string) (string, error) {
 		// and before " in goroutine [...]".
 		idx := strings.Index(after, " in goroutine")
 		if idx >= 0 {
-			name = after[:idx]
+			after = after[:idx]
 		}
+		name = after
 	} else if idx := strings.LastIndexByte(line, '('); idx >= 0 {
 		// The function name is the part before the last '('.
 		name = line[:idx]

--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -153,6 +153,9 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 		fullStack.WriteByte('\n') // scanner trims the newline
 
 		if len(line) == 0 {
+			// Empty line usually marks the end of the stack
+			// but we don't want to have to rely on that.
+			// Just skip it.
 			continue
 		}
 

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -177,7 +177,12 @@ func TestParseFuncName(t *testing.T) {
 			want: "example.com/foo/bar.(*baz).qux",
 		},
 		{
-			name: "created by",
+			name: "created by", // Go 1.20
+			give: "created by example.com/foo/bar.baz",
+			want: "example.com/foo/bar.baz",
+		},
+		{
+			name: "created by/in goroutine", // Go 1.21
 			give: "created by example.com/foo/bar.baz in goroutine 123",
 			want: "example.com/foo/bar.baz",
 		},

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -105,6 +105,9 @@ func TestCurrent(t *testing.T) {
 	assert.True(t, got.HasFunction("testing.(*T).Run"),
 		"missing in stack: %v\n%s", "testing.(*T).Run", all)
 
+	assert.Contains(t, all, "stack/stacks_test.go",
+		"file name missing in stack:\n%s", all)
+
 	// Ensure that we are not returning the buffer without slicing it
 	// from getStackBuffer.
 	if len(got.Full()) > 1024 {

--- a/internal/stack/testdata/Makefile
+++ b/internal/stack/testdata/Makefile
@@ -1,0 +1,27 @@
+.DEFAULT_GOAL := all
+
+GO_VERSION = $(shell go version | cut -d' ' -f3)
+
+# Append to this list to add new stacks.
+STACKS =
+
+# In Go 1.21, the output format was changed slightly.
+#
+# Generate a 1.20 version of the output
+# only if we're running on Go 1.20.
+ifneq (,$(findstring go1.20,$(GO_VERSION)))
+STACKS += http.go1.20.txt
+http.go1.20.txt: http.go
+	go run $< > $@
+else
+STACKS += http.txt
+http.txt: http.go
+	go run $< > $@
+endif
+
+STACKS += http.tracebackancestors.txt
+http.tracebackancestors.txt: http.go
+	GODEBUG=tracebackancestors=10 go run $< > $@
+
+.PHONY: all
+all: $(STACKS)

--- a/internal/stack/testdata/http.go
+++ b/internal/stack/testdata/http.go
@@ -1,0 +1,48 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+func main() {
+	if err := start(); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(getStackBuffer()))
+}
+
+func start() error {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return err
+	}
+
+	go http.Serve(ln, nil)
+
+	// Wait until HTTP server is ready.
+	url := "http://" + ln.Addr().String()
+	for i := 0; i < 10; i++ {
+		if _, err := http.Get(url); err == nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf("failed to start HTTP server")
+}
+
+func getStackBuffer() []byte {
+	for i := 4096; ; i *= 2 {
+		buf := make([]byte, i)
+		if n := runtime.Stack(buf, true /* all */); n < i {
+			return buf[:n]
+		}
+	}
+}

--- a/internal/stack/testdata/http.go1.20.txt
+++ b/internal/stack/testdata/http.go1.20.txt
@@ -1,0 +1,64 @@
+goroutine 1 [running]:
+main.getStackBuffer()
+	/home/abg/src/goleak/internal/stack/testdata/http.go:44 +0x4f
+main.main()
+	/home/abg/src/goleak/internal/stack/testdata/http.go:18 +0x2a
+
+goroutine 20 [IO wait]:
+internal/poll.runtime_pollWait(0x7866b1e34f08, 0x72)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/runtime/netpoll.go:306 +0x89
+internal/poll.(*pollDesc).wait(0xc0000dc000?, 0x16?, 0x0)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/internal/poll/fd_poll_runtime.go:84 +0x32
+internal/poll.(*pollDesc).waitRead(...)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc0000dc000)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/internal/poll/fd_unix.go:614 +0x2bd
+net.(*netFD).accept(0xc0000dc000)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/fd_unix.go:172 +0x35
+net.(*TCPListener).accept(0xc0000a00f0)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/tcpsock_posix.go:148 +0x25
+net.(*TCPListener).Accept(0xc0000a00f0)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/tcpsock.go:297 +0x3d
+net/http.(*Server).Serve(0xc000076000, {0x73dbe0, 0xc0000a00f0})
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/server.go:3059 +0x385
+net/http.Serve({0x73dbe0, 0xc0000a00f0}, {0x0?, 0x0})
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/server.go:2581 +0x74
+created by main.start
+	/home/abg/src/goleak/internal/stack/testdata/http.go:27 +0x8e
+
+goroutine 24 [select]:
+net/http.(*persistConn).readLoop(0xc0000b4480)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/transport.go:2227 +0xd85
+created by net/http.(*Transport).dialConn
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/transport.go:1765 +0x16ea
+
+goroutine 25 [select]:
+net/http.(*persistConn).writeLoop(0xc0000b4480)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/transport.go:2410 +0xf2
+created by net/http.(*Transport).dialConn
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/transport.go:1766 +0x173d
+
+goroutine 4 [IO wait]:
+internal/poll.runtime_pollWait(0x7866b1e34d28, 0x72)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/runtime/netpoll.go:306 +0x89
+internal/poll.(*pollDesc).wait(0xc00007e000?, 0xc000106000?, 0x0)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/internal/poll/fd_poll_runtime.go:84 +0x32
+internal/poll.(*pollDesc).waitRead(...)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc00007e000, {0xc000106000, 0x1000, 0x1000})
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/internal/poll/fd_unix.go:167 +0x299
+net.(*netFD).Read(0xc00007e000, {0xc000106000?, 0x4a92e6?, 0x0?})
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/fd_posix.go:55 +0x29
+net.(*conn).Read(0xc000014028, {0xc000106000?, 0x0?, 0xc0000781e8?})
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/net.go:183 +0x45
+net/http.(*connReader).Read(0xc0000781e0, {0xc000106000, 0x1000, 0x1000})
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/server.go:782 +0x171
+bufio.(*Reader).fill(0xc000104000)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/bufio/bufio.go:106 +0xff
+bufio.(*Reader).Peek(0xc000104000, 0x4)
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/bufio/bufio.go:144 +0x5d
+net/http.(*conn).serve(0xc000100000, {0x73df98, 0xc0000780f0})
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/server.go:2030 +0x77c
+created by net/http.(*Server).Serve
+	/home/abg/.gimme/versions/go1.20.10.linux.amd64/src/net/http/server.go:3089 +0x5ed
+

--- a/internal/stack/testdata/http.tracebackancestors.txt
+++ b/internal/stack/testdata/http.tracebackancestors.txt
@@ -1,0 +1,145 @@
+goroutine 1 [running]:
+main.getStackBuffer()
+	/home/abg/src/goleak/internal/stack/testdata/http.go:44 +0x49
+main.main()
+	/home/abg/src/goleak/internal/stack/testdata/http.go:18 +0x1d
+
+goroutine 20 [IO wait]:
+internal/poll.runtime_pollWait(0x7c3a3d619e48, 0x72)
+	/usr/lib/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc0000da000?, 0x16?, 0x0)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc0000da000)
+	/usr/lib/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc0000da000)
+	/usr/lib/go/src/net/fd_unix.go:172 +0x29
+net.(*TCPListener).accept(0xc0000ba0c0)
+	/usr/lib/go/src/net/tcpsock_posix.go:152 +0x1e
+net.(*TCPListener).Accept(0xc0000ba0c0)
+	/usr/lib/go/src/net/tcpsock.go:315 +0x30
+net/http.(*Server).Serve(0xc000078000, {0x738a20, 0xc0000ba0c0})
+	/usr/lib/go/src/net/http/server.go:3056 +0x364
+net/http.Serve({0x738a20, 0xc0000ba0c0}, {0x0?, 0x0})
+	/usr/lib/go/src/net/http/server.go:2595 +0x6c
+created by main.start in goroutine 1
+	/home/abg/src/goleak/internal/stack/testdata/http.go:27 +0x87
+[originating from goroutine 1]:
+main.start(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:30 +0x87
+main.main(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:14 +0x13
+
+goroutine 24 [select]:
+net/http.(*persistConn).readLoop(0xc0000be480)
+	/usr/lib/go/src/net/http/transport.go:2238 +0xd25
+created by net/http.(*Transport).dialConn in goroutine 21
+	/usr/lib/go/src/net/http/transport.go:1776 +0x169f
+[originating from goroutine 21]:
+net/http.(*Transport).dialConn(...)
+	/usr/lib/go/src/net/http/transport.go:1777 +0x169f
+net/http.(*Transport).dialConnFor(...)
+	/usr/lib/go/src/net/http/transport.go:1469 +0x9f
+created by net/http.(*Transport).queueForDial
+	/usr/lib/go/src/net/http/transport.go:1436 +0x3cb
+[originating from goroutine 1]:
+net/http.(*Transport).queueForDial(...)
+	/usr/lib/go/src/net/http/transport.go:1437 +0x3cb
+net/http.(*Request).Context(...)
+	/usr/lib/go/src/net/http/request.go:346 +0x4c9
+net/http.(*Transport).roundTrip(...)
+	/usr/lib/go/src/net/http/transport.go:591 +0x73a
+net/http.(*Transport).RoundTrip(...)
+	/usr/lib/go/src/net/http/roundtrip.go:17 +0x13
+net/http.send(...)
+	/usr/lib/go/src/net/http/client.go:260 +0x606
+net/http.(*Client).send(...)
+	/usr/lib/go/src/net/http/client.go:182 +0x98
+net/http.(*Client).do(...)
+	/usr/lib/go/src/net/http/client.go:724 +0x912
+net/http.(*Client).Get(...)
+	/usr/lib/go/src/net/http/client.go:488 +0x5f
+net/http.(*Client).Get(...)
+	/usr/lib/go/src/net/http/client.go:488 +0x60
+main.start(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:32 +0x111
+main.start(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:32 +0x112
+main.main(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:14 +0x13
+
+goroutine 4 [IO wait]:
+internal/poll.runtime_pollWait(0x7c3a3d619d50, 0x72)
+	/usr/lib/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc00007e000?, 0xc000106000?, 0x0)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc00007e000, {0xc000106000, 0x1000, 0x1000})
+	/usr/lib/go/src/internal/poll/fd_unix.go:164 +0x27a
+net.(*netFD).Read(0xc00007e000, {0xc000106000?, 0x4a8965?, 0x0?})
+	/usr/lib/go/src/net/fd_posix.go:55 +0x25
+net.(*conn).Read(0xc000046018, {0xc000106000?, 0x0?, 0xc000064248?})
+	/usr/lib/go/src/net/net.go:179 +0x45
+net/http.(*connReader).Read(0xc000064240, {0xc000106000, 0x1000, 0x1000})
+	/usr/lib/go/src/net/http/server.go:791 +0x14b
+bufio.(*Reader).fill(0xc000104000)
+	/usr/lib/go/src/bufio/bufio.go:113 +0x103
+bufio.(*Reader).Peek(0xc000104000, 0x4)
+	/usr/lib/go/src/bufio/bufio.go:151 +0x53
+net/http.(*conn).serve(0xc000100000, {0x739108, 0xc000064150})
+	/usr/lib/go/src/net/http/server.go:2044 +0x75c
+created by net/http.(*Server).Serve in goroutine 20
+	/usr/lib/go/src/net/http/server.go:3086 +0x5cb
+[originating from goroutine 20]:
+net/http.(*Server).Serve(...)
+	/usr/lib/go/src/net/http/server.go:3086 +0x5cb
+net/http.Serve(...)
+	/usr/lib/go/src/net/http/server.go:2595 +0x6c
+created by main.start
+	/home/abg/src/goleak/internal/stack/testdata/http.go:27 +0x87
+[originating from goroutine 1]:
+main.start(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:30 +0x87
+main.main(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:14 +0x13
+
+goroutine 25 [select]:
+net/http.(*persistConn).writeLoop(0xc0000be480)
+	/usr/lib/go/src/net/http/transport.go:2421 +0xe5
+created by net/http.(*Transport).dialConn in goroutine 21
+	/usr/lib/go/src/net/http/transport.go:1777 +0x16f1
+[originating from goroutine 21]:
+net/http.(*Transport).dialConn(...)
+	/usr/lib/go/src/net/http/transport.go:1778 +0x16f1
+net/http.(*Transport).dialConnFor(...)
+	/usr/lib/go/src/net/http/transport.go:1469 +0x9f
+created by net/http.(*Transport).queueForDial
+	/usr/lib/go/src/net/http/transport.go:1436 +0x3cb
+[originating from goroutine 1]:
+net/http.(*Transport).queueForDial(...)
+	/usr/lib/go/src/net/http/transport.go:1437 +0x3cb
+net/http.(*Request).Context(...)
+	/usr/lib/go/src/net/http/request.go:346 +0x4c9
+net/http.(*Transport).roundTrip(...)
+	/usr/lib/go/src/net/http/transport.go:591 +0x73a
+net/http.(*Transport).RoundTrip(...)
+	/usr/lib/go/src/net/http/roundtrip.go:17 +0x13
+net/http.send(...)
+	/usr/lib/go/src/net/http/client.go:260 +0x606
+net/http.(*Client).send(...)
+	/usr/lib/go/src/net/http/client.go:182 +0x98
+net/http.(*Client).do(...)
+	/usr/lib/go/src/net/http/client.go:724 +0x912
+net/http.(*Client).Get(...)
+	/usr/lib/go/src/net/http/client.go:488 +0x5f
+net/http.(*Client).Get(...)
+	/usr/lib/go/src/net/http/client.go:488 +0x60
+main.start(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:32 +0x111
+main.start(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:32 +0x112
+main.main(...)
+	/home/abg/src/goleak/internal/stack/testdata/http.go:14 +0x13
+

--- a/internal/stack/testdata/http.txt
+++ b/internal/stack/testdata/http.txt
@@ -1,0 +1,64 @@
+goroutine 1 [running]:
+main.getStackBuffer()
+	/home/abg/src/goleak/internal/stack/testdata/http.go:44 +0x49
+main.main()
+	/home/abg/src/goleak/internal/stack/testdata/http.go:18 +0x1d
+
+goroutine 4 [IO wait]:
+internal/poll.runtime_pollWait(0x7bf130ae7ea0, 0x72)
+	/usr/lib/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc000132000?, 0x4?, 0x0)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc000132000)
+	/usr/lib/go/src/internal/poll/fd_unix.go:611 +0x2ac
+net.(*netFD).accept(0xc000132000)
+	/usr/lib/go/src/net/fd_unix.go:172 +0x29
+net.(*TCPListener).accept(0xc0000600e0)
+	/usr/lib/go/src/net/tcpsock_posix.go:152 +0x1e
+net.(*TCPListener).Accept(0xc0000600e0)
+	/usr/lib/go/src/net/tcpsock.go:315 +0x30
+net/http.(*Server).Serve(0xc00008c000, {0x738a20, 0xc0000600e0})
+	/usr/lib/go/src/net/http/server.go:3056 +0x364
+net/http.Serve({0x738a20, 0xc0000600e0}, {0x0?, 0x0})
+	/usr/lib/go/src/net/http/server.go:2595 +0x6c
+created by main.start in goroutine 1
+	/home/abg/src/goleak/internal/stack/testdata/http.go:27 +0x87
+
+goroutine 20 [select]:
+net/http.(*persistConn).readLoop(0xc000112480)
+	/usr/lib/go/src/net/http/transport.go:2238 +0xd25
+created by net/http.(*Transport).dialConn in goroutine 5
+	/usr/lib/go/src/net/http/transport.go:1776 +0x169f
+
+goroutine 21 [select]:
+net/http.(*persistConn).writeLoop(0xc000112480)
+	/usr/lib/go/src/net/http/transport.go:2421 +0xe5
+created by net/http.(*Transport).dialConn in goroutine 5
+	/usr/lib/go/src/net/http/transport.go:1777 +0x16f1
+
+goroutine 8 [IO wait]:
+internal/poll.runtime_pollWait(0x7bf130ae7cb0, 0x72)
+	/usr/lib/go/src/runtime/netpoll.go:343 +0x85
+internal/poll.(*pollDesc).wait(0xc000132200?, 0xc000142000?, 0x0)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/lib/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc000132200, {0xc000142000, 0x1000, 0x1000})
+	/usr/lib/go/src/internal/poll/fd_unix.go:164 +0x27a
+net.(*netFD).Read(0xc000132200, {0xc000142000?, 0x4a8965?, 0x0?})
+	/usr/lib/go/src/net/fd_posix.go:55 +0x25
+net.(*conn).Read(0xc000044070, {0xc000142000?, 0x0?, 0xc00007ad28?})
+	/usr/lib/go/src/net/net.go:179 +0x45
+net/http.(*connReader).Read(0xc00007ad20, {0xc000142000, 0x1000, 0x1000})
+	/usr/lib/go/src/net/http/server.go:791 +0x14b
+bufio.(*Reader).fill(0xc000102540)
+	/usr/lib/go/src/bufio/bufio.go:113 +0x103
+bufio.(*Reader).Peek(0xc000102540, 0x4)
+	/usr/lib/go/src/bufio/bufio.go:151 +0x53
+net/http.(*conn).serve(0xc000134240, {0x739108, 0xc00008e0f0})
+	/usr/lib/go/src/net/http/server.go:2044 +0x75c
+created by net/http.(*Server).Serve in goroutine 4
+	/usr/lib/go/src/net/http/server.go:3086 +0x5cb
+


### PR DESCRIPTION
Adds support to the stack parser for reading the full list of functions
for a stack trace.

NOTE:
This includes the function that created the stack trace;
it's the bottom of the stack.

We don't maintain the order of the functions
since that's not something we need at this time.
The functions are all placed in a set.

This unblocks #41 (PR incoming)
and allows implementing an IgnoreAnyFunction option
(similar to #80 that has since stalled).

Depends on #110
