### PR TITLE
ignores: Don't use strings.Contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Built-in ignores now match function names more accurately.
+  They will no longer ignore stacks because of file names
+  that look similar to function names.
 
 ## [1.2.1]
 ### Changed

--- a/options.go
+++ b/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2017-2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -197,7 +197,7 @@ func isTestStack(s stack.Stack) bool {
 func isSyscallStack(s stack.Stack) bool {
 	// Typically runs in the background when code uses CGo:
 	// https://github.com/golang/go/issues/16714
-	return s.FirstFunction() == "runtime.goexit" && strings.HasPrefix(s.State(), "syscall")
+	return s.HasFunction("runtime.goexit") && strings.HasPrefix(s.State(), "syscall")
 }
 
 func isStdLibStack(s stack.Stack) bool {
@@ -208,5 +208,5 @@ func isStdLibStack(s stack.Stack) bool {
 	}
 
 	// Using signal.Notify will start a runtime goroutine.
-	return strings.Contains(s.Full(), "runtime.ensureSigM")
+	return s.HasFunction("runtime.ensureSigM")
 }

--- a/tracestack_new.go
+++ b/tracestack_new.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2021-2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,8 @@
 
 package goleak
 
-import (
-	"strings"
-
-	"go.uber.org/goleak/internal/stack"
-)
+import "go.uber.org/goleak/internal/stack"
 
 func isTraceStack(s stack.Stack) bool {
-	return strings.Contains(s.Full(), "runtime.ReadTrace")
+	return s.HasFunction("runtime.ReadTrace")
 }


### PR DESCRIPTION
Instead of matching for built-in functions with strings.Contains,
use the parsed stack information to match function names exactly.

Following this change, the only remaining strings.Contains are
to match on the goroutine state:

```
% rg strings.Contains
utils_test.go
84:             if strings.Contains(s.State(), "run") {

internal/stack/stacks_test.go
249:            if strings.Contains(s.State(), "run") {
```

Resolves #41
Depends on #111
