### PR TITLE
README: Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ No breaking changes will be made to exported APIs before 2.0.
 
 [doc-img]: https://godoc.org/go.uber.org/goleak?status.svg
 [doc]: https://godoc.org/go.uber.org/goleak
-[ci-img]: https://github.com/uber-go/goleak/actions/workflows/go.yml/badge.svg
-[ci]: https://github.com/uber-go/goleak/actions/workflows/go.yml
+[ci-img]: https://github.com/uber-go/goleak/actions/workflows/ci.yml/badge.svg
+[ci]: https://github.com/uber-go/goleak/actions/workflows/ci.yml
 [cov-img]: https://codecov.io/gh/uber-go/goleak/branch/master/graph/badge.svg
 [cov]: https://codecov.io/gh/uber-go/goleak
 [release]: https://go.dev/doc/devel/release#policy


### PR DESCRIPTION
The CI job was renamed to ci.yml in #108
but the README.md was not updated.

Fix the badge URL in the README.
