### PR TITLE
gracefully handle elided frames

### DIFF
--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -25,16 +25,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 )
 
 const _defaultBufferSize = 64 * 1024 // 64 KiB
-
-// elidedFramesMatcher matches lines that indicate frames were elided; these cannot be parsed as functions.
-var elidedFramesMatcher = regexp.MustCompile(`\.\.\.\d+ frames elided\.\.\.`)
 
 // Stack represents a single Goroutine's stack.
 type Stack struct {
@@ -162,7 +158,7 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 			// Just skip it.
 			continue
 		}
-		if elidedFramesMatcher.MatchString(line) {
+		if strings.HasPrefix(line, "...") && strings.HasSuffix(line, " frames elided...") {
 			// e.g. ...23 frames elided...
 			// This indicates frames were elided from the stack trace,
 			// attempting to parse them via parseFuncName will fail resulting in a panic

--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -34,7 +34,7 @@ import (
 const _defaultBufferSize = 64 * 1024 // 64 KiB
 
 // elidedFramesMatcher matches lines that indicate frames were elided; these cannot be parsed as functions.
-var elidedFramesMatcher = regexp.MustCompile(`\.\.\.\s*\d+ frames elided\s*\.\.\.`)
+var elidedFramesMatcher = regexp.MustCompile(`\.\.\.\d+ frames elided\.\.\.`)
 
 // Stack represents a single Goroutine's stack.
 type Stack struct {

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -165,8 +165,8 @@ func TestAllLargeStack(t *testing.T) {
 	}
 
 	// Also test the stack parser here to ensure it handles elided frames,
-	// and that if the format elided frames take changes at any time we catch it.
-	// At the time of writing this test, with a stack depth of 101, we get 2 elided frames.
+	// and that if the format elided frames changes at any time we catch it.
+	// At the time of writing this test, with a stack depth of 101, we get 2 elided frames:
 	// "...2 frames elided...".
 	_, err := newStackParser(bytes.NewReader(buf)).Parse()
 	require.NoError(t, err)

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -263,6 +263,23 @@ func TestParseStack(t *testing.T) {
 				"example.com/foo/bar.baz",
 			},
 		},
+		{
+			name: "elided frames",
+			give: joinLines(
+				"goroutine 1 [running]:",
+				"example.com/foo/bar.baz()",
+				"	example.com/foo/bar.go:123",
+				"... 3 frames elided ...",
+				"created by example.com/foo/bar.qux",
+				"	example.com/foo/bar.go:456",
+			),
+			id:        1,
+			state:     "running",
+			firstFunc: "example.com/foo/bar.baz",
+			funcs: []string{
+				"example.com/foo/bar.baz",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -168,8 +168,10 @@ func TestAllLargeStack(t *testing.T) {
 	// We want to check this here, so that if the format of the "elided frames" message changes, we catch it.
 	// At the time of writing this test, with a stack depth of 101, we get 2 elided frames:
 	// "...2 frames elided...".
-	_, err := newStackParser(bytes.NewReader(buf)).Parse()
+	assert.Contains(t, string(buf), "frames elided...")
+	stacks, err := newStackParser(bytes.NewReader(buf)).Parse()
 	require.NoError(t, err)
+	assert.Greater(t, len(stacks), numGoroutines, "expect more parsed stacks than goroutines")
 
 	// Start enough goroutines so we exceed the default buffer size.
 	close(done)

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -164,8 +164,8 @@ func TestAllLargeStack(t *testing.T) {
 		t.Fatalf("Expected larger stack buffer")
 	}
 
-	// Also test the stack parser here to ensure it handles elided frames,
-	// and that if the format elided frames changes at any time we catch it.
+	// Also test the stack parser here to ensure it handles elided frames gracefully.
+	// We want to check this here, so that if the format of the "elided frames" message changes, we catch it.
 	// At the time of writing this test, with a stack depth of 101, we get 2 elided frames:
 	// "...2 frames elided...".
 	_, err := newStackParser(bytes.NewReader(buf)).Parse()

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -269,7 +269,7 @@ func TestParseStack(t *testing.T) {
 				"goroutine 1 [running]:",
 				"example.com/foo/bar.baz()",
 				"	example.com/foo/bar.go:123",
-				"... 3 frames elided ...",
+				"...3 frames elided...",
 				"created by example.com/foo/bar.qux",
 				"	example.com/foo/bar.go:456",
 			),

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -21,6 +21,7 @@
 package stack
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -136,8 +137,8 @@ func TestCurrentCreatedBy(t *testing.T) {
 
 func TestAllLargeStack(t *testing.T) {
 	const (
-		stackDepth    = 100
-		numGoroutines = 100
+		stackDepth    = 101
+		numGoroutines = 101
 	)
 
 	var started sync.WaitGroup
@@ -162,6 +163,13 @@ func TestAllLargeStack(t *testing.T) {
 	if len(buf) <= _defaultBufferSize {
 		t.Fatalf("Expected larger stack buffer")
 	}
+
+	// Also test the stack parser here to ensure it handles elided frames,
+	// and that if the format elided frames take changes at any time we catch it.
+	// At the time of writing this test, with a stack depth of 101, we get 2 elided frames.
+	// "...2 frames elided...".
+	_, err := newStackParser(bytes.NewReader(buf)).Parse()
+	require.NoError(t, err)
 
 	// Start enough goroutines so we exceed the default buffer size.
 	close(done)


### PR DESCRIPTION
When parsing stacks we frequently encounter elided frames. The actual stack line looks something like `...23 frames elided...`, which is passed to `parseFuncName`, which of course is not parsable as a function name. As a result, whenever this happens we get a useless panic like the following:

```
panic: Failed to parse stack trace: parse function: no function found: "...23 frames elided..."
goroutine 1 [running]:
go.uber.org/goleak/internal/stack.getStackBuffer(0x1)
	/home/runner/go/pkg/mod/go.uber.org/goleak@v1.3.0/internal/stack/stacks.go:240 +0x65
go.uber.org/goleak/internal/stack.getStacks(0x1)
	/home/runner/go/pkg/mod/go.uber.org/goleak@v1.3.0/internal/stack/stacks.go:84 +0x3b
go.uber.org/goleak/internal/stack.All(...)
	/home/runner/go/pkg/mod/go.uber.org/goleak@v1.3.0/internal/stack/stacks.go:229
go.uber.org/goleak.Find({0xc0003ae880, 0x4, 0x4})
	/home/runner/go/pkg/mod/go.uber.org/goleak@v1.3.0/leaks.go:65 +0x1ea
```

This PR gracefully handles elided frames to prevent the panic.