### PR TITLE
Fix lint and upgrade versions to 1.21/1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
       name: Install golangci-lint
       with:
         version: latest
-        args: --version  # make lint will run the linter
+        # Hack: Use the official action to download, but not run.
+        # make lint below will handle actually running the linter.
+        args: --help
 
     - run: make lint
       name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20.x", "1.21.x"]
+        go: ["1.21.x", "1.22.x"]
 
     steps:
     - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/setup-go@v4
       name: Set up Go
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: false  # managed by golangci-lint
 
     - uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Follow-up to #120, I accidentally merged the PR without waiting for all tests to run, and missed that 1.20 tests are failing.

Lint is failing because of how we skip golangci-lint run in the action and use the Makefile. Use the same logic as zap to skip lint.

Tests are failing on 1.20 as stack elision doesn't kick in for the test. From 1.21 onwards, it does kick in. Rather than try to make the test trigger stack elision on 1.20, let's bump the versions to 1.21 / 1.22.