### PR TITLE
CI: Upgrade to codecov 4 & use token.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
       run: make cover
 
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint


### PR DESCRIPTION
This upgrades codecov CI action to version 4,
and uses the codecov token when uploading,
since tokenless uploading is no longer supported for some cases.