### PR TITLE
README: replace deprecated godoc links with new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ goleak is v1 and follows [SemVer](http://semver.org/) strictly.
 
 No breaking changes will be made to exported APIs before 2.0.
 
-[doc-img]: https://godoc.org/go.uber.org/goleak?status.svg
-[doc]: https://godoc.org/go.uber.org/goleak
+[doc-img]: https://pkg.go.dev/badge/go.uber.org/goleak.svg
+[doc]: https://pkg.go.dev/go.uber.org/goleak
 [ci-img]: https://github.com/uber-go/goleak/actions/workflows/ci.yml/badge.svg
 [ci]: https://github.com/uber-go/goleak/actions/workflows/ci.yml
 [cov-img]: https://codecov.io/gh/uber-go/goleak/branch/master/graph/badge.svg

--- a/testmain.go
+++ b/testmain.go
@@ -45,7 +45,7 @@ type TestingM interface {
 //	  goleak.VerifyTestMain(m)
 //	}
 //
-// See https://golang.org/pkg/testing/#hdr-Main for more details.
+// See https://pkg.go.dev/testing#hdr-Main for more details.
 //
 // This will run all tests as per normal, and if they were successful, look
 // for any goroutine leaks and fail the tests if any leaks were found.


### PR DESCRIPTION
This PR replaces the deprecated `GoDoc` links with new ones to `Go Reference` in `README.md`.

See https://github.com/golang/go/issues/49212 for details about the deprecated `godoc`.
The badge is created at https://pkg.go.dev/badge/.