### PR TITLE
fix: ensure the appropriate error message is produced when the RunOnFailure() option is used.

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -59,9 +59,6 @@ func Find(options ...Option) error {
 	if opts.cleanup != nil {
 		return errors.New("Cleanup can only be passed to VerifyNone or VerifyTestMain")
 	}
-	if opts.runOnFailure {
-		return errors.New("RunOnFailure can only be passed to VerifyTestMain")
-	}
 	var stacks []stack.Stack
 	retry := true
 	for i := 0; retry; i++ {

--- a/options.go
+++ b/options.go
@@ -109,8 +109,9 @@ func IgnoreCurrent() Option {
 	})
 }
 
-// RunOnFailure makes goleak look for leaking goroutines upon test failures.
-// By default goleak only looks for leaking goroutines when tests succeed.
+// RunOnFailure makes [VerifyTestMain] look for leaking goroutines upon test failures as well.
+// By default [VerifyTestMain] only looks for leaking goroutines when tests succeed.
+// This has no effect on [VerifyNone], which always checks for leaking goroutines.
 func RunOnFailure() Option {
 	return optionFunc(func(opts *opts) {
 		opts.runOnFailure = true

--- a/testmain.go
+++ b/testmain.go
@@ -65,7 +65,7 @@ func VerifyTestMain(m TestingM, options ...Option) {
 		errorMsg string
 	)
 
-	if !opts.runOnFailure && exitCode == 0 {
+	if exitCode == 0 {
 		errorMsg = "goleak: Errors on successful test run:%v\n"
 		run = true
 	} else if opts.runOnFailure {

--- a/testmain_test.go
+++ b/testmain_test.go
@@ -69,11 +69,15 @@ func TestVerifyTestMain(t *testing.T) {
 
 	VerifyTestMain(dummyTestMain(7), RunOnFailure())
 	assert.Equal(t, 7, <-exitCode, "Exit code should not be modified")
-	assert.Contains(t, <-stderr, "goleak: Errors", "Find leaks on unsuccessful runs with RunOnFailure specified")
+	assert.Contains(t, <-stderr, "goleak: Errors on unsuccessful test run", "Find leaks on unsuccessful runs with RunOnFailure specified")
 
 	VerifyTestMain(dummyTestMain(0))
 	assert.Equal(t, 1, <-exitCode, "Expect error due to leaks on successful runs")
-	assert.Contains(t, <-stderr, "goleak: Errors", "Find leaks on successful runs")
+	assert.Contains(t, <-stderr, "goleak: Errors on successful test run", "Find leaks on successful runs")
+
+	VerifyTestMain(dummyTestMain(0), RunOnFailure())
+	assert.Equal(t, 1, <-exitCode, "Expect error due to leaks on successful runs")
+	assert.Contains(t, <-stderr, "goleak: Errors on successful test run", "Find leaks on successful runs")
 
 	blocked.unblock()
 	VerifyTestMain(dummyTestMain(0))


### PR DESCRIPTION
adjust RunOnFailure() doc.

follow up to https://github.com/uber-go/goleak/pull/129