### PR TITLE
clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ func TestMain(m *testing.M) {
 }
 ```
 
+### Note
+
+For tests that use [t.Parallel](https://pkg.go.dev/testing#T.Parallel), `goleak` does
+not know how to distinguish a leaky goroutine from tests that have not finished running.
+
+
+```go
+func TestA(t *testing.T) {
+	tt := struct{
+		name  	 string
+		input 	 SomeType
+		expected string
+	}{
+		// ...
+	}
+
+	for _, t := range tt {
+		t.Run(t.name, func(t *testing.T) {
+			t.Parallel() // <- goleak gets confused here!
+
+			// ...
+		}
+	}
+}
+```
+For such cases you should also defer to using `goleak.VerifyTestMain` as shown above.
+
 ## Determine Source of Package Leaks
 
 When verifying leaks using `TestMain`, the leak test is only run once after all tests


### PR DESCRIPTION
someone at Uber unfortunately spent cycles trying to convert VerifyTestMain call to VerifyNone(t) for individual cases only to find out that it doesn't work well with t.Parallel().

Even though VerifyNone(t)'s documentation already says this, it might be worth clarifying this in the README since the wording can make it sound like calling VerifyTestMain() vs calling VerifyNone() at the end of every single test case is completely identical in behavior.