### PR TITLE
fix: Handle leading whitespace in elided frames marker

### DIFF
--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -158,8 +158,10 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 			// Just skip it.
 			continue
 		}
-		if strings.HasPrefix(line, "...") && strings.HasSuffix(line, " frames elided...") {
-			// e.g. ...23 frames elided...
+
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "...") && strings.HasSuffix(trimmedLine, " frames elided...") {
+			// e.g. "...23 frames elided..." or "        ...23 frames elided..."
 			// This indicates frames were elided from the stack trace,
 			// attempting to parse them via parseFuncName will fail resulting in a panic
 			// and a relatively useless output. Gracefully handle this.


### PR DESCRIPTION
Fixes panic when parsing stack traces with indented elided frames marker.

### Problem
Go's runtime can elide frames in very deep stack traces (e.g., AWS SDK v2 middleware with 33+ frames). The elision marker `...N frames elided...` appears with leading whitespace (tabs/spaces), but the parser only checked for lines starting with `...`.

When the indented marker wasn't caught, it was passed to `parseFuncName()`, causing a panic: `no function found: "...33 frames elided..."`

### Solution
Trim whitespace before checking for the elision marker pattern. This allows both indented and non-indented markers to be handled gracefully.

### Example (Go 1.25.1)
```
        github.com/aws/aws-sdk-go-v2/service/sqs.(*disableHTTPSMiddleware).HandleFinalize(...)
        	/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/sqs@v1.42.11/api_client.go:864 +0x143
        ...33 frames elided...
        github.com/aws/aws-sdk-go-v2/aws/middleware.ClientRequestID.HandleBuild(...)
        	/go/pkg/mod/github.com/aws/aws-sdk-go-v2@v1.39.4/aws/middleware/middleware.go:42 +0x1e5
```

Note the leading whitespace before `...33 frames elided...`.