### PR TITLE
ci: upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
         go-version: 1.23.x
         cache: false  # managed by golangci-lint
 
-    - uses: golangci/golangci-lint-action@v6
+    - uses: golangci/golangci-lint-action@v9
       name: Install golangci-lint
       with:
-        version: v1.64.8
+        version: v2.11.3
         # Hack: Use the official action to download, but not run.
         # make lint below will handle actually running the linter.
         args: --help

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,31 +1,32 @@
-output:
-  # Make output more digestible with quickfix in vim/emacs/etc.
-  sort-results: true
-  print-issued-lines: false
+version: "2"
 
 linters:
+  default: none
   enable:
-    - gofumpt
+    - errcheck
+    - govet
+    - ineffassign
     - nolintlint
     - revive
-
-linters-settings:
-  govet:
-    # These govet checks are disabled by default, but they're useful.
-    enable:
-      - nilness
-      - reflectvaluecompare
-      - sortslice
-      - unusedwrite
-  errcheck:
-    exclude-functions:
-      - fmt.Fprintf
+    - staticcheck
+    - unused
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprintf
+    govet:
+      # These govet checks are disabled by default, but they're useful.
+      enable:
+        - nilness
+        - reflectvaluecompare
+        - sortslice
+        - unusedwrite
 
 issues:
   # Print all issues reported by all linters.
   max-issues-per-linter: 0
   max-same-issues: 0
 
-  # Don't ignore some of the issues that golangci-lint considers okay.
-  # This includes documenting all exported entities.
-  exclude-use-default: false
+formatters:
+  enable:
+    - gofumpt

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -55,10 +55,7 @@ func TestAll(t *testing.T) {
 	got := All()
 
 	// Retry until the background stacks are not runnable/running.
-	for {
-		if !isBackgroundRunning(cur, got) {
-			break
-		}
+	for isBackgroundRunning(cur, got) {
 		runtime.Gosched()
 		got = All()
 	}


### PR DESCRIPTION
Because golangci-lint v1 is deprecated and no longer receives updates.