### PR TITLE
filter: add default filter for pure-Go DNS resolver goroutines

### DIFF
--- a/options.go
+++ b/options.go
@@ -222,8 +222,8 @@ func isTraceStack(s stack.Stack) bool {
 }
 
 func isDNSResolverStack(s stack.Stack) bool {
-	// On Linux (and other Unix platforms where cgo is not used),
-	// Go's pure-Go DNS resolver spawns goroutines for parallel
-	// A/AAAA lookups that may briefly outlive the caller.
-	return s.HasFunction("net.(*Resolver).goLookupIPCNAMEOrder")
+	// net.Resolver is a public type covered by the Go 1 compatibility
+	// guarantee; matching on the receiver keeps this filter stable even
+	// if internal method names are renamed or refactored.
+	return strings.HasPrefix(s.CreatedBy(), "net.(*Resolver).")
 }

--- a/options.go
+++ b/options.go
@@ -148,6 +148,7 @@ func buildOpts(options ...Option) *opts {
 		isSyscallStack,
 		isStdLibStack,
 		isTraceStack,
+		isDNSResolverStack,
 	)
 	for _, option := range options {
 		option.apply(opts)
@@ -218,4 +219,11 @@ func isStdLibStack(s stack.Stack) bool {
 
 func isTraceStack(s stack.Stack) bool {
 	return s.HasFunction("runtime.ReadTrace")
+}
+
+func isDNSResolverStack(s stack.Stack) bool {
+	// On Linux (and other Unix platforms where cgo is not used),
+	// Go's pure-Go DNS resolver spawns goroutines for parallel
+	// A/AAAA lookups that may briefly outlive the caller.
+	return s.HasFunction("net.(*Resolver).goLookupIPCNAMEOrder")
 }


### PR DESCRIPTION
Fixes #141

Go's pure-Go DNS resolver (default on Linux, not macOS) spawns transient goroutines for parallel A/AAAA lookups that can outlive the test on slow CI machines, causing false positives. Everyone ends up adding:
```go
goleak.IgnoreAnyFunction("net.(*Resolver).goLookupIPCNAMEOrder.func4")
```

Should be a built-in default filter alongside `isStdLibStack`.

References:
- [`goLookupIPCNAMEOrder` parallel goroutine spawning](https://github.com/golang/go/blob/go1.23.0/src/net/dnsclient_unix.go#L664-L671) — the `go func(qtype)` goroutine for A/AAAA lookups
- [`goosPrefersCgo` returning true for darwin](https://github.com/golang/go/blob/go1.23.0/src/net/conf.go#L178-L182) — why macOS is unaffected
- [golang/go#25523](https://github.com/golang/go/issues/25523) — proposal acknowledging stdlib goroutine noise in leak detection
- [gitlab-org/gitaly#4551](https://gitlab.com/gitlab-org/gitaly/-/issues/4551) — same symptom, same workaround