### PR TITLE
IgnoreAnyFunction: also check the created-by frame

### DIFF
--- a/options.go
+++ b/options.go
@@ -70,7 +70,7 @@ func IgnoreTopFunction(f string) Option {
 }
 
 // IgnoreAnyFunction ignores goroutines where the specified function
-// is present anywhere in the stack.
+// is present anywhere in the stack, including the "created by" frame.
 //
 // The function name must be fully qualified, e.g.,
 //
@@ -81,7 +81,7 @@ func IgnoreTopFunction(f string) Option {
 //	go.uber.org/goleak.(*MyType).MyMethod
 func IgnoreAnyFunction(f string) Option {
 	return addFilter(func(s stack.Stack) bool {
-		return s.HasFunction(f)
+		return s.HasFunction(f) || s.CreatedBy() == f
 	})
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -64,11 +64,11 @@ func TestOptionsFilters(t *testing.T) {
 	opts = buildOpts(IgnoreTopFunction("go.uber.org/goleak.(*blockedG).block"))
 	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", stack.All())
 
-	// If we ignore startBlockedG, that should not ignore the blockedG goroutine
-	// because startBlockedG should be the "created by" function in the stack.
+	// IgnoreAnyFunction also matches the "created by" frame, so ignoring
+	// startBlockedG should filter out the blockedG goroutine.
 	opts = buildOpts(IgnoreAnyFunction("go.uber.org/goleak.startBlockedG"))
-	require.Equal(t, 1, countUnfiltered(),
-		"startBlockedG should not be filtered out. running: %v", stack.All())
+	require.Zero(t, countUnfiltered(),
+		"startBlockedG created-by frame should cause blockedG to be filtered out. running: %v", stack.All())
 }
 
 func TestOptionsIgnoreCreatedBy(t *testing.T) {
@@ -108,6 +108,27 @@ func TestOptionsIgnoreAnyFunction(t *testing.T) {
 		}
 
 		t.Errorf("Unexpected goroutine: %v", s)
+	}
+}
+
+func TestOptionsIgnoreAnyFunctionCreatedBy(t *testing.T) {
+	defer startBlockedG().unblock()
+
+	cur := stack.Current()
+	// startBlockedG appears only in the "created by" line of the spawned goroutine,
+	// not in its own call stack. IgnoreAnyFunction should still filter it.
+	opts := buildOpts(IgnoreAnyFunction("go.uber.org/goleak.startBlockedG"))
+
+	for _, s := range stack.All() {
+		if s.ID() == cur.ID() {
+			continue
+		}
+
+		if opts.filter(s) {
+			continue
+		}
+
+		t.Errorf("Unexpected goroutine (created-by frame not matched): %v", s)
 	}
 }
 


### PR DESCRIPTION
Fixes #135.

`IgnoreAnyFunction` is documented as ignoring goroutines where the specified function is present "anywhere in the stack", but it was only checking `allFunctions`, which doesn't include the "created by" frame. If a goroutine was spawned by the function you're trying to ignore, the filter had no effect.

The fix is a one-liner: check `s.CreatedBy() == f` alongside `s.HasFunction(f)`.

I also updated the existing test in `TestOptionsFilters` that was asserting the old behavior (and had a comment explaining why `startBlockedG` wouldn't match), and added a new `TestOptionsIgnoreAnyFunctionCreatedBy` that directly covers this case.