### PR TITLE
filter: add default filter for the pure-Go DNS resolver

### DIFF
--- a/options.go
+++ b/options.go
@@ -148,6 +148,7 @@ func buildOpts(options ...Option) *opts {
 		isSyscallStack,
 		isStdLibStack,
 		isTraceStack,
+		isDNSResolverStack,
 	)
 	for _, option := range options {
 		option.apply(opts)
@@ -218,4 +219,18 @@ func isStdLibStack(s stack.Stack) bool {
 
 func isTraceStack(s stack.Stack) bool {
 	return s.HasFunction("runtime.ReadTrace")
+}
+
+// isDNSResolverStack matches the transient goroutines that the pure-Go DNS
+// resolver spawns during parallel A/AAAA lookups. The resolver is the default
+// on Linux (and on macOS when CGO_ENABLED=0), and on slow machines those
+// lookups can outlive the test that triggered them, producing false-positive
+// leaks. See https://github.com/uber-go/goleak/issues/141.
+//
+// The closure goroutines are spawned inside goLookupIPCNAMEOrder, so their
+// "created by" line points there and the in-stack function is one of the
+// generated .funcN names. Match on the creator so we don't have to enumerate
+// every closure index (which can change between Go versions).
+func isDNSResolverStack(s stack.Stack) bool {
+	return s.CreatedBy() == "net.(*Resolver).goLookupIPCNAMEOrder"
 }


### PR DESCRIPTION
Closes #141.

Go's pure-Go DNS resolver (default on Linux and on macOS when \`CGO_ENABLED=0\`) spawns transient closure goroutines inside \`net.(*Resolver).goLookupIPCNAMEOrder\` to run parallel A/AAAA lookups. On slow CI machines those goroutines can outlive the test that triggered them, so users keep adding the same one-line escape hatch:

\`\`\`go
goleak.IgnoreAnyFunction(\"net.(*Resolver).goLookupIPCNAMEOrder.func4\")
\`\`\`

This promotes that to a default filter alongside \`isStdLibStack\`, so the workaround isn't needed anymore.

The filter matches on \`CreatedBy\` rather than an inner \`.funcN\` name so it survives Go version bumps that may renumber the closures (which would otherwise quietly stop matching).

## Test plan

\`\`\`
go test ./...
\`\`\`

Existing \`TestOptionsFilters\` exercises the default filter list — no new tests for the filter itself because constructing a synthetic \`stack.Stack\` with the right \`CreatedBy\` would need the internal parser, and running a real DNS lookup as an integration test is non-deterministic across systems (cgo vs pure-Go resolver). Happy to add an integration test if you'd prefer.