### PR TITLE
ci: test on Go 1.25 and 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.22.x", "1.23.x"]
+        go: ["1.25.x", "1.26.x"]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
We haven't updated the CI in a while.

Make the CI run tests on latest two Go versions.