### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -29,7 +29,7 @@ import (
 
 // TestingT is the minimal subset of testing.TB that we use.
 type TestingT interface {
-	Error(...interface{})
+	Error(...any)
 }
 
 // filterStacks will filter any stacks excluded by the given opts.

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -78,7 +78,7 @@ type fakeT struct {
 	errors []string
 }
 
-func (ft *fakeT) Error(args ...interface{}) {
+func (ft *fakeT) Error(args ...any) {
 	ft.errors = append(ft.errors, fmt.Sprint(args...))
 }
 


### PR DESCRIPTION
Replace `interface{}` with `any` (Go 1.18+ alias).