### PR TITLE
stack: skip traceback ancestor blocks while parsing

### DIFF
--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -174,6 +174,15 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 			// and a relatively useless output. Gracefully handle this.
 			continue
 		}
+		if isTracebackAncestorHeader(line) {
+			if err := p.appendUntilNextGoroutine(&fullStack); err != nil {
+				return Stack{}, fmt.Errorf("parse traceback ancestor: %w", err)
+			}
+			break
+		}
+		if err := checkTracebackAncestorHeader(line); err != nil {
+			return Stack{}, fmt.Errorf("parse traceback ancestor: %w", err)
+		}
 
 		funcName, creator, err := parseFuncName(line)
 		if err != nil {
@@ -212,22 +221,15 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 		}
 
 		if creator {
-			// The "created by" line is the last line of the stack.
-			// We can stop parsing now.
-			//
-			// Note that if tracebackancestors=N is set,
-			// there may be more a traceback of the creator function
-			// following the "created by" line,
-			// but it should not be considered part of this stack.
-			// e.g.,
-			//
-			// created by testing.(*T).Run in goroutine 1
-			//         /usr/lib/go/src/testing/testing.go:1648 +0x3ad
-			// [originating from goroutine 1]:
-			// testing.(*T).Run(...)
-			//         /usr/lib/go/src/testing/testing.go:1649 +0x3ad
-			//
+			// The "created by" line ends the live stack frames.
+			// With GODEBUG=tracebackancestors=N, runtime.Stack may
+			// append creation ancestry after this line. Preserve that
+			// raw text in Full, but do not parse it as functions from
+			// the current live stack.
 			createdBy = funcName
+			if err := p.appendNextTracebackAncestorBlock(&fullStack); err != nil {
+				return Stack{}, fmt.Errorf("parse traceback ancestor: %w", err)
+			}
 			break
 		}
 	}
@@ -290,6 +292,67 @@ func parseFuncName(line string) (name string, creator bool, err error) {
 	}
 
 	return name, creator, nil
+}
+
+const tracebackAncestorPrefix = "[originating from goroutine "
+
+func isTracebackAncestorHeader(line string) bool {
+	id, ok := strings.CutPrefix(line, tracebackAncestorPrefix)
+	if !ok {
+		return false
+	}
+	id, ok = strings.CutSuffix(id, "]:")
+	if !ok || id == "" {
+		return false
+	}
+
+	_, err := strconv.ParseUint(id, 10, 64)
+	return err == nil
+}
+
+func (p *stackParser) appendUntilNextGoroutine(fullStack *bytes.Buffer) error {
+	for p.scan.Scan() {
+		line := p.scan.Text()
+		if strings.HasPrefix(line, "goroutine ") {
+			p.scan.Unscan()
+			return nil
+		}
+		if err := checkTracebackAncestorHeader(line); err != nil {
+			return err
+		}
+		fullStack.WriteString(line)
+		fullStack.WriteByte('\n')
+	}
+	return nil
+}
+
+func checkTracebackAncestorHeader(line string) error {
+	if !strings.HasPrefix(line, tracebackAncestorPrefix) {
+		return nil
+	}
+	if !isTracebackAncestorHeader(line) {
+		return fmt.Errorf("bad traceback ancestor header: %q", line)
+	}
+	return nil
+}
+
+func (p *stackParser) appendNextTracebackAncestorBlock(fullStack *bytes.Buffer) error {
+	if !p.scan.Scan() {
+		return nil
+	}
+
+	line := p.scan.Text()
+	if err := checkTracebackAncestorHeader(line); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(line, tracebackAncestorPrefix) {
+		p.scan.Unscan()
+		return nil
+	}
+
+	fullStack.WriteString(line)
+	fullStack.WriteByte('\n')
+	return p.appendUntilNextGoroutine(fullStack)
 }
 
 // parseGoStackHeader parses a stack header that looks like:

--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -221,11 +221,19 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 		}
 
 		if creator {
-			// The "created by" line ends the live stack frames.
+			// The "created by" line ends the live stack frames for
+			// this goroutine, so the creator function is the last
+			// function we should parse into Stack.funcs.
+			//
 			// With GODEBUG=tracebackancestors=N, runtime.Stack may
-			// append creation ancestry after this line. Preserve that
-			// raw text in Full, but do not parse it as functions from
-			// the current live stack.
+			// still append ancestry text after the "created by" line:
+			//
+			//   created by testing.(*T).Run in goroutine 1
+			//   [originating from goroutine 1]:
+			//   testing.(*T).Run(...)
+			//
+			// Keep that raw traceback ancestor text in Stack.Full(),
+			// but do not treat it as live frames for this goroutine.
 			createdBy = funcName
 			if err := p.appendNextTracebackAncestorBlock(&fullStack); err != nil {
 				return Stack{}, fmt.Errorf("parse traceback ancestor: %w", err)

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -108,10 +108,12 @@ func TestCurrent(t *testing.T) {
 	assert.Contains(t, all, "stack/stacks_test.go",
 		"file name missing in stack:\n%s", all)
 
-	// Ensure that we are not returning the buffer without slicing it
-	// from getStackBuffer.
-	if len(got.Full()) > 1024 {
-		t.Fatalf("Returned stack is too large")
+	// Ensure that we are not returning the full buffer from getStackBuffer.
+	// Traceback ancestors can legitimately make the current stack larger than
+	// the old small sanity limit, but an unsliced buffer would still be the
+	// default buffer size.
+	if len(got.Full()) >= _defaultBufferSize {
+		t.Fatalf("Returned stack is too large: %d", len(got.Full()))
 	}
 }
 
@@ -314,6 +316,162 @@ func TestParseStack(t *testing.T) {
 	}
 }
 
+func TestParseStackSkipsTracebackAncestorBlocks(t *testing.T) {
+	t.Run("without live created by", func(t *testing.T) {
+		give := joinLines(
+			"goroutine 1 [running]:",
+			"example.com/foo/bar.baz()",
+			"	example.com/foo/bar.go:123",
+			"[originating from goroutine 7]:",
+			"example.com/foo/bar.qux(...)",
+			"	example.com/foo/bar.go:456",
+			"created by example.com/foo/bar.parent in goroutine 1",
+			"	example.com/foo/parent.go:12",
+			"goroutine 2 [select]:",
+			"example.com/foo/bar.wait()",
+			"	example.com/foo/bar.go:789",
+		)
+
+		stacks, err := newStackParser(strings.NewReader(give)).Parse()
+		require.NoError(t, err)
+		require.Len(t, stacks, 2)
+
+		stack := stacks[0]
+		assert.Equal(t, 1, stack.ID())
+		assert.Equal(t, "running", stack.State())
+		assert.Equal(t, "example.com/foo/bar.baz", stack.FirstFunction())
+		assert.Empty(t, stack.CreatedBy())
+
+		assert.True(t, stack.HasFunction("example.com/foo/bar.baz"))
+		assert.False(t, stack.HasFunction("example.com/foo/bar.qux"))
+		assert.False(t, stack.HasFunction("example.com/foo/bar.parent"))
+
+		assert.Contains(t, stack.Full(), "[originating from goroutine 7]:")
+		assert.Contains(t, stack.Full(), "example.com/foo/bar.qux(...)")
+		assert.Contains(t, stack.Full(), "created by example.com/foo/bar.parent in goroutine 1")
+
+		assert.Equal(t, 2, stacks[1].ID())
+		assert.Equal(t, "example.com/foo/bar.wait", stacks[1].FirstFunction())
+	})
+
+	t.Run("after live created by", func(t *testing.T) {
+		give := joinLines(
+			"goroutine 1 [select]:",
+			"example.com/foo/bar.baz()",
+			"	example.com/foo/bar.go:123",
+			"created by example.com/foo/bar.creator in goroutine 5",
+			"	example.com/foo/creator.go:12",
+			"[originating from goroutine 5]:",
+			"example.com/foo/bar.creator(...)",
+			"	example.com/foo/creator.go:13",
+			"created by example.com/foo/bar.parent",
+			"	example.com/foo/parent.go:14",
+			"goroutine 2 [select]:",
+			"example.com/foo/bar.wait()",
+			"	example.com/foo/bar.go:789",
+		)
+
+		stacks, err := newStackParser(strings.NewReader(give)).Parse()
+		require.NoError(t, err)
+		require.Len(t, stacks, 2)
+
+		stack := stacks[0]
+		assert.Equal(t, 1, stack.ID())
+		assert.Equal(t, "select", stack.State())
+		assert.Equal(t, "example.com/foo/bar.baz", stack.FirstFunction())
+		assert.Equal(t, "example.com/foo/bar.creator", stack.CreatedBy())
+
+		assert.True(t, stack.HasFunction("example.com/foo/bar.baz"))
+		assert.False(t, stack.HasFunction("example.com/foo/bar.creator"))
+		assert.False(t, stack.HasFunction("example.com/foo/bar.parent"))
+
+		assert.Contains(t, stack.Full(), "created by example.com/foo/bar.creator in goroutine 5")
+		assert.Contains(t, stack.Full(), "[originating from goroutine 5]:")
+		assert.Contains(t, stack.Full(), "example.com/foo/bar.creator(...)")
+		assert.Contains(t, stack.Full(), "created by example.com/foo/bar.parent")
+
+		assert.Equal(t, 2, stacks[1].ID())
+		assert.Equal(t, "example.com/foo/bar.wait", stacks[1].FirstFunction())
+	})
+
+	t.Run("until EOF", func(t *testing.T) {
+		give := joinLines(
+			"goroutine 1 [running]:",
+			"example.com/foo/bar.baz()",
+			"	example.com/foo/bar.go:123",
+			"[originating from goroutine 7]:",
+			"example.com/foo/bar.qux(...)",
+			"	example.com/foo/bar.go:456",
+		)
+
+		stacks, err := newStackParser(strings.NewReader(give)).Parse()
+		require.NoError(t, err)
+		require.Len(t, stacks, 1)
+
+		stack := stacks[0]
+		assert.Equal(t, 1, stack.ID())
+		assert.Equal(t, "example.com/foo/bar.baz", stack.FirstFunction())
+		assert.True(t, stack.HasFunction("example.com/foo/bar.baz"))
+		assert.False(t, stack.HasFunction("example.com/foo/bar.qux"))
+		assert.Contains(t, stack.Full(), "[originating from goroutine 7]:")
+		assert.Contains(t, stack.Full(), "example.com/foo/bar.qux(...)")
+	})
+}
+
+func TestParseStackRejectsMalformedTracebackAncestorHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+	}{
+		{
+			name: "before live created by",
+			give: joinLines(
+				"goroutine 1 [running]:",
+				"example.com/foo/bar.baz()",
+				"	example.com/foo/bar.go:123",
+				"[originating from goroutine nope]:",
+				"example.com/foo/bar.qux(...)",
+				"	example.com/foo/bar.go:456",
+			),
+		},
+		{
+			name: "after live created by",
+			give: joinLines(
+				"goroutine 1 [running]:",
+				"example.com/foo/bar.baz()",
+				"	example.com/foo/bar.go:123",
+				"created by example.com/foo/bar.creator",
+				"	example.com/foo/creator.go:12",
+				"[originating from goroutine nope]:",
+				"example.com/foo/bar.qux(...)",
+				"	example.com/foo/bar.go:456",
+			),
+		},
+		{
+			name: "nested inside valid ancestry block",
+			give: joinLines(
+				"goroutine 1 [running]:",
+				"example.com/foo/bar.baz()",
+				"	example.com/foo/bar.go:123",
+				"[originating from goroutine 7]:",
+				"example.com/foo/bar.qux(...)",
+				"	example.com/foo/bar.go:456",
+				"[originating from goroutine nope]:",
+				"example.com/foo/bar.parent(...)",
+				"	example.com/foo/parent.go:12",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newStackParser(strings.NewReader(tt.give)).Parse()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, `bad traceback ancestor header`)
+		})
+	}
+}
+
 func TestParseStackErrors(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -361,6 +519,7 @@ func TestParseStackFixtures(t *testing.T) {
 
 		HasFunctions    []string // non-exhaustive, in any order
 		NotHasFunctions []string
+		FullContains    []string
 	}
 
 	tests := []struct {
@@ -479,6 +638,10 @@ func TestParseStackFixtures(t *testing.T) {
 						"main.start", // created by
 						"main.main",  // tracebackancestors
 					},
+					FullContains: []string{
+						"[originating from goroutine 1]:",
+						"main.start(...)",
+					},
 				},
 				{
 					ID:            24,
@@ -560,6 +723,10 @@ func TestParseStackFixtures(t *testing.T) {
 
 				for _, fn := range wantStack.NotHasFunctions {
 					assert.False(t, gotStack.HasFunction(fn), "unexpected in stack: %v\n%s", fn, gotStack.Full())
+				}
+
+				for _, fragment := range wantStack.FullContains {
+					assert.Contains(t, gotStack.Full(), fragment)
 				}
 			}
 


### PR DESCRIPTION
## Summary

`GODEBUG=tracebackancestors=N` can add `[originating from goroutine N]:`
sections to `runtime.Stack` output. These sections are diagnostic ancestry
metadata for a goroutine, not functions on that goroutine's live stack.

The parser currently attempts to parse an ancestor header as a function when
the section appears before a `created by` line stops parsing, which causes:

```text
Failed to parse stack trace: parse function: no function found: "[originating from goroutine 1]:"
```

## Change

- Recognize traceback ancestor section headers.
- Preserve the raw ancestry text in `Stack.Full()`, including ancestry that
  follows a live `created by` frame.
- Exclude ancestor functions from `HasFunction`, `FirstFunction`, and `CreatedBy`.
- Keep malformed ancestry-looking headers as parser errors.
- Add regression tests for ancestry before a live `created by` line, after a
  live `created by` line, and at EOF.
- Cover a following live goroutine header so the skip logic cannot accidentally
  consume the next goroutine stack.
- Extend the real `http.tracebackancestors.txt` fixture with `Stack.Full()`
  assertions for preserved raw ancestry text.
- Relax the current-stack size sanity check so it still catches an unsliced
  stack buffer while allowing larger real stacks when traceback ancestors are
  enabled.

## Related context

- `uber-go/goleak#70` tracks general `tracebackancestors` support.
- `uber-go/goleak#111` introduced the `http.tracebackancestors.txt` fixture and
  created-by parsing behavior that this fix extends. It does not already parse
  `[originating from goroutine N]:` headers.
- `uber-go/goleak#120` is a merged precedent for preventing parser panics on
  runtime stack metadata lines.
- `uber-go/goleak#138` is an open, similar parser-panic shape for elided frame
  markers with leading whitespace; this PR handles a different line shape.

## Validation

- `go test ./internal/stack -run '^TestParseStack' -count=1`
- `go test ./internal/stack -count=1`
- `go test ./... -count=1`
- `GODEBUG=tracebackancestors=10 go test ./... -count=1`
