### PR TITLE
docs: fix typo in IgnoreCreatedBy doc comment

### DIFF
--- a/options.go
+++ b/options.go
@@ -85,7 +85,7 @@ func IgnoreAnyFunction(f string) Option {
 	})
 }
 
-// IgnoreCreatedBy ignores any goroutines that where spawned from the
+// IgnoreCreatedBy ignores any goroutines that were spawned from the
 // specified function. The function name should be fully qualified, e.g.
 // go.uber.org/goleak.IgnoreCreatedBy.
 func IgnoreCreatedBy(f string) Option {


### PR DESCRIPTION
### Summary
- Fix minor typo in doc comment for `IgnoreCreatedBy` in `options.go` (`that where spawned` -> `that were spawned`).