### PR TITLE
chore: bump coverage to 100

### DIFF
--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -89,12 +89,17 @@ func (s Stack) String() string {
 }
 
 func getStacks(all bool) []Stack {
-	trace := getStackBuffer(all)
+	return parseStacks(getStackBuffer(all))
+}
+
+// parseStacks parses a stack trace produced by runtime.Stack.
+//
+// It panics if the trace is malformed, since well-formed stack traces
+// produced by the runtime should never fail to parse.
+// If they do, it's a bug in this package, and panicking lets us fix it.
+func parseStacks(trace []byte) []Stack {
 	stacks, err := newStackParser(bytes.NewReader(trace)).Parse()
 	if err != nil {
-		// Well-formed stack traces should never fail to parse.
-		// If they do, it's a bug in this package.
-		// Panic so we can fix it.
 		panic(fmt.Sprintf("Failed to parse stack trace: %v\n%s", err, trace))
 	}
 	return stacks

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -177,6 +177,26 @@ func TestAllLargeStack(t *testing.T) {
 	close(done)
 }
 
+func TestParseStacksPanicsOnMalformedTrace(t *testing.T) {
+	// getStacks relies on runtime.Stack always producing well-formed
+	// traces, and panics if parsing ever fails. Exercise that path
+	// directly with a malformed trace since the runtime won't produce one.
+	malformed := []byte("goroutine no-number [running]:\n")
+
+	recovered := func() (recovered any) {
+		defer func() { recovered = recover() }()
+		parseStacks(malformed)
+		return
+	}()
+
+	msg, ok := recovered.(string)
+	require.True(t, ok, "panic value should be a string, got %T", recovered)
+	assert.Contains(t, msg, "Failed to parse stack trace")
+	assert.Contains(t, msg, "bad goroutine ID")
+	// The offending trace should be included to aid debugging.
+	assert.Contains(t, msg, string(malformed))
+}
+
 func TestParseFuncName(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Split out getStacks into parseStacks so we can cover the panic