### PR TITLE
ci: test on Go 1.27, drop 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.25.x", "1.26.x"]
+        go: ["1.26.x", "1.27.x"]
 
     steps:
     - name: Checkout code
@@ -44,13 +44,13 @@ jobs:
     - uses: actions/setup-go@v4
       name: Set up Go
       with:
-        go-version: 1.23.x
+        go-version: 1.27.x
         cache: false  # managed by golangci-lint
 
     - uses: golangci/golangci-lint-action@v9
       name: Install golangci-lint
       with:
-        version: v2.11.3
+        version: v2.13.1
         # Hack: Use the official action to download, but not run.
         # make lint below will handle actually running the linter.
         args: --help


### PR DESCRIPTION
Go 1.27 has been released. Update the CI matrix to test on 1.26.x and 1.27.x, and run lint on 1.27.x.

golangci-lint v2.11.3 is built with go1.26 and panics with `file requires newer Go version go1.27` when type-checking 1.27 sources, so bump the pin to v2.13.1.