### PR TITLE
Skip leak detection when goroutine stacks can't be parsed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,32 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  tinygo:
+    name: TinyGo
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Setup Go
+      # Pin a Go version supported by this TinyGo release; the main test
+      # matrix uses newer Go that TinyGo does not support yet.
+      uses: actions/setup-go@v4
+      with:
+        go-version: "1.25.x"
+
+    - name: Setup TinyGo
+      uses: acifani/setup-tinygo@v3
+      with:
+        tinygo-version: "0.40.1"
+
+    # Verify goleak builds and runs under TinyGo without panicking. TinyGo
+    # defines the "tinygo" build tag, so it picks up ./internal/tinygocheck,
+    # which standard Go tooling ignores. `run` (not `build`) is required: the
+    # original bug was a runtime panic, not a compile error.
+    - name: Smoke test
+      run: tinygo run ./internal/tinygocheck
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Don't panic when running under a runtime that produces no parseable goroutine
+  stacks, such as TinyGo. goleak now skips leak detection in that case:
+  `VerifyNone` and `VerifyTestMain` log a message and skip the check instead of
+  crashing. (#72)
+
+[Unreleased]: https://github.com/uber-go/goleak/compare/v1.3.0...HEAD
+
 ## [1.3.0]
 ### Fixed
 - Built-in ignores now match function names more accurately.

--- a/internal/stack/stacks.go
+++ b/internal/stack/stacks.go
@@ -88,8 +88,21 @@ func (s Stack) String() string {
 		s.id, s.state, s.firstFunction, s.Full())
 }
 
-func getStacks(all bool) []Stack {
-	return parseStacks(getStackBuffer(all))
+// ErrNoStacks is returned by Current and All when goleak cannot obtain any
+// parseable goroutine stacks — e.g. under TinyGo, whose runtime.Stack output
+// goleak does not recognise. It means leak detection cannot run, as opposed
+// to there being no leaked goroutines.
+var ErrNoStacks = errors.New("goleak: no goroutine stacks were parsed")
+
+func getStacks(all bool) ([]Stack, error) {
+	stacks := parseStacks(getStackBuffer(all))
+	if len(stacks) == 0 {
+		// runtime.Stack always yields at least the current goroutine on
+		// standard Go; an empty result means a runtime whose format we can't
+		// parse (e.g. TinyGo). Report it instead of indexing an empty slice.
+		return nil, ErrNoStacks
+	}
+	return stacks, nil
 }
 
 // parseStacks parses a stack trace produced by runtime.Stack.
@@ -248,19 +261,27 @@ func (p *stackParser) parseStack(line string) (Stack, error) {
 }
 
 // All returns the stacks for all running goroutines.
-func All() []Stack {
+func All() ([]Stack, error) {
 	return getStacks(true)
 }
 
 // Current returns the stack for the current goroutine.
-func Current() Stack {
-	return getStacks(false)[0]
+func Current() (Stack, error) {
+	stacks, err := getStacks(false)
+	if err != nil {
+		return Stack{}, err
+	}
+	return stacks[0], nil
 }
+
+// _runtimeStack is runtime.Stack, stubbed in tests to exercise unusual
+// runtime output (e.g. TinyGo, which produces no parseable stacks).
+var _runtimeStack = runtime.Stack
 
 func getStackBuffer(all bool) []byte {
 	for i := _defaultBufferSize; ; i *= 2 {
 		buf := make([]byte, i)
-		if n := runtime.Stack(buf, all); n < i {
+		if n := _runtimeStack(buf, all); n < i {
 			return buf[:n]
 		}
 	}

--- a/internal/stack/stacks_test.go
+++ b/internal/stack/stacks_test.go
@@ -61,13 +61,16 @@ func TestAll(t *testing.T) {
 		_workersDone.Wait()
 	}()
 
-	cur := Current()
-	got := All()
+	cur, err := Current()
+	require.NoError(t, err)
+	got, err := All()
+	require.NoError(t, err)
 
 	// Retry until the background stacks are not runnable/running.
 	for isBackgroundRunning(cur, got) {
 		runtime.Gosched()
-		got = All()
+		got, err = All()
+		require.NoError(t, err)
 	}
 
 	// We have exactly 7 goroutines:
@@ -107,7 +110,8 @@ func TestAll(t *testing.T) {
 func TestCurrent(t *testing.T) {
 	const pkgPrefix = "go.uber.org/goleak/internal/stack"
 
-	got := Current()
+	got, err := Current()
+	require.NoError(t, err)
 	assert.NotZero(t, got.ID(), "Should get non-zero goroutine id")
 	assert.Equal(t, "running", got.State())
 	assert.Equal(t, "go.uber.org/goleak/internal/stack.getStackBuffer", got.FirstFunction())
@@ -143,7 +147,7 @@ func TestCurrentCreatedBy(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		stack = Current()
+		stack, _ = Current()
 	}()
 	<-done
 
@@ -156,6 +160,20 @@ func TestCurrentCreatedBy(t *testing.T) {
 	assert.True(t,
 		stack.HasFunction("go.uber.org/goleak/internal/stack.TestCurrentCreatedBy.func1"),
 		"TestCurrentCreatedBy.func1 is not in stack:\n%s", stack.Full())
+}
+
+func TestNoStacks(t *testing.T) {
+	// Simulate a runtime (e.g. TinyGo) whose runtime.Stack produces no
+	// parseable output: Current and All should report ErrNoStacks rather
+	// than panicking.
+	defer func(orig func([]byte, bool) int) { _runtimeStack = orig }(_runtimeStack)
+	_runtimeStack = func([]byte, bool) int { return 0 }
+
+	_, err := Current()
+	require.ErrorIs(t, err, ErrNoStacks)
+
+	_, err = All()
+	require.ErrorIs(t, err, ErrNoStacks)
 }
 
 func TestAllLargeStack(t *testing.T) {

--- a/internal/tinygocheck/main.go
+++ b/internal/tinygocheck/main.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build tinygo
+
+// Command tinygocheck is a smoke test that verifies goleak builds and runs
+// under TinyGo without panicking.
+//
+// TinyGo's runtime.Stack produces no output that goleak can parse, which used
+// to make goleak panic with an index-out-of-range error. goleak now detects
+// that and skips its checks instead; this program exercises that path.
+//
+// It is built only by TinyGo, which defines the "tinygo" build tag; standard
+// Go tooling (build, test, vet, lint, coverage) ignores this file.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/goleak"
+)
+
+// recordingT implements goleak.TestingT and the optional Logf method, so we
+// can observe whether goleak fails the check or merely skips it.
+type recordingT struct {
+	failed bool
+}
+
+func (t *recordingT) Error(args ...any) {
+	t.failed = true
+	fmt.Println("goleak reported:", fmt.Sprint(args...))
+}
+
+func (t *recordingT) Logf(format string, args ...any) {
+	fmt.Printf(format+"\n", args...)
+}
+
+type noopM struct{}
+
+func (noopM) Run() int { return 0 }
+
+func fail(msg string) {
+	fmt.Println("FAIL:", msg)
+	os.Exit(1)
+}
+
+func main() {
+	// None of the calls below must panic under TinyGo.
+
+	// Find reports that stacks are unavailable rather than crashing.
+	if err := goleak.Find(); err != nil {
+		fmt.Println("Find:", err)
+	}
+
+	// VerifyNone must skip (not fail) when stacks can't be parsed.
+	rt := &recordingT{}
+	goleak.VerifyNone(rt)
+	if rt.failed {
+		fail("VerifyNone reported a leak under TinyGo")
+	}
+
+	// IgnoreCurrent must also degrade gracefully.
+	goleak.VerifyNone(rt, goleak.IgnoreCurrent())
+	if rt.failed {
+		fail("VerifyNone(IgnoreCurrent) reported a leak under TinyGo")
+	}
+
+	// VerifyTestMain must not panic. Cleanup overrides the default os.Exit so
+	// this program stays in control of its own exit.
+	goleak.VerifyTestMain(noopM{}, goleak.Cleanup(func(int) {}))
+
+	fmt.Println("PASS: goleak ran under TinyGo without panicking")
+}

--- a/leaks.go
+++ b/leaks.go
@@ -50,10 +50,23 @@ func filterStacks(stacks []stack.Stack, skipID int, opts *opts) []stack.Stack {
 	return filtered
 }
 
+// Stubbed in tests.
+var (
+	_stackCurrent = stack.Current
+	_stackAll     = stack.All
+)
+
 // Find looks for extra goroutines, and returns a descriptive error if
 // any are found.
+//
+// If goleak is unable to parse goroutine stacks (for example under TinyGo),
+// Find returns an error and no leak check is performed.
 func Find(options ...Option) error {
-	cur := stack.Current().ID()
+	cur, err := _stackCurrent()
+	if err != nil {
+		return err
+	}
+	curID := cur.ID()
 
 	opts := buildOpts(options...)
 	if opts.cleanup != nil {
@@ -65,7 +78,11 @@ func Find(options ...Option) error {
 	var stacks []stack.Stack
 	retry := true
 	for i := 0; retry; i++ {
-		stacks = filterStacks(stack.All(), cur, opts)
+		all, err := _stackAll()
+		if err != nil {
+			return err
+		}
+		stacks = filterStacks(all, curID, opts)
 
 		if len(stacks) == 0 {
 			return nil
@@ -80,6 +97,18 @@ type testHelper interface {
 	Helper()
 }
 
+// testLogger is the optional subset of testing.TB used to report that leak
+// detection was skipped. If t doesn't implement it, the skip is silent.
+type testLogger interface {
+	Logf(string, ...any)
+}
+
+func logf(t TestingT, format string, args ...any) {
+	if l, ok := t.(testLogger); ok {
+		l.Logf(format, args...)
+	}
+}
+
 // VerifyNone marks the given TestingT as failed if any extra goroutines are
 // found by Find. This is a helper method to make it easier to integrate in
 // tests by doing:
@@ -91,6 +120,10 @@ type testHelper interface {
 // goroutines from other tests running in parallel could fail this check.
 // If you need to run tests in parallel, use [VerifyTestMain] instead,
 // which will verify that no leaking goroutines exist after ALL tests finish.
+//
+// If goleak is unable to parse goroutine stacks (for example under TinyGo),
+// the check is skipped rather than failed; when t provides a Logf method, a
+// message is logged noting that leak detection was skipped.
 func VerifyNone(t TestingT, options ...Option) {
 	opts := buildOpts(options...)
 	var cleanup func(int)
@@ -102,7 +135,12 @@ func VerifyNone(t TestingT, options ...Option) {
 	}
 
 	if err := Find(opts); err != nil {
-		t.Error(err)
+		if errors.Is(err, stack.ErrNoStacks) {
+			// goleak can't run here (e.g. TinyGo); skip rather than fail.
+			logf(t, "%v; skipping goroutine leak detection", err)
+		} else {
+			t.Error(err)
+		}
 	}
 
 	if cleanup != nil {

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak/internal/stack"
 )
 
 // Ensure that testingT is a subset of testing.TB.
@@ -80,6 +82,65 @@ type fakeT struct {
 
 func (ft *fakeT) Error(args ...any) {
 	ft.errors = append(ft.errors, fmt.Sprint(args...))
+}
+
+// fakeTLogf extends fakeT with a Logf method, matching the optional
+// testLogger interface used to report skipped leak detection.
+type fakeTLogf struct {
+	fakeT
+	logs []string
+}
+
+func (ft *fakeTLogf) Logf(format string, args ...any) {
+	ft.logs = append(ft.logs, fmt.Sprintf(format, args...))
+}
+
+// stubStackFuncs replaces the stack.Current/stack.All seams so that goleak
+// behaves as if the runtime produced no parseable stacks (e.g. TinyGo).
+func stubStackFuncs(t *testing.T) {
+	origCurrent, origAll := _stackCurrent, _stackAll
+	t.Cleanup(func() {
+		_stackCurrent, _stackAll = origCurrent, origAll
+	})
+	_stackCurrent = func() (stack.Stack, error) { return stack.Stack{}, stack.ErrNoStacks }
+	_stackAll = func() ([]stack.Stack, error) { return nil, stack.ErrNoStacks }
+}
+
+func TestFindNoStacks(t *testing.T) {
+	t.Run("Current fails", func(t *testing.T) {
+		origCurrent := _stackCurrent
+		t.Cleanup(func() { _stackCurrent = origCurrent })
+		_stackCurrent = func() (stack.Stack, error) { return stack.Stack{}, stack.ErrNoStacks }
+
+		require.ErrorIs(t, Find(), stack.ErrNoStacks)
+	})
+
+	t.Run("All fails", func(t *testing.T) {
+		// Current succeeds, so the error must come from the All call.
+		origAll := _stackAll
+		t.Cleanup(func() { _stackAll = origAll })
+		_stackAll = func() ([]stack.Stack, error) { return nil, stack.ErrNoStacks }
+
+		require.ErrorIs(t, Find(), stack.ErrNoStacks)
+	})
+}
+
+func TestVerifyNoneNoStacks(t *testing.T) {
+	stubStackFuncs(t)
+
+	t.Run("logs and skips when logger available", func(t *testing.T) {
+		ft := &fakeTLogf{}
+		VerifyNone(ft)
+		require.Empty(t, ft.errors, "leak detection should be skipped, not failed")
+		require.Len(t, ft.logs, 1, "should log that leak detection was skipped")
+		assert.Contains(t, ft.logs[0], "skipping goroutine leak detection")
+	})
+
+	t.Run("skips silently without logger", func(t *testing.T) {
+		ft := &fakeT{}
+		VerifyNone(ft) // must neither panic nor fail
+		require.Empty(t, ft.errors, "leak detection should be skipped, not failed")
+	})
 }
 
 func TestVerifyNone(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -110,8 +110,12 @@ func Cleanup(cleanupFunc func(exitCode int)) Option {
 // them in any future Find/Verify calls.
 func IgnoreCurrent() Option {
 	excludeIDSet := map[int]bool{}
-	for _, s := range stack.All() {
-		excludeIDSet[s.ID()] = true
+	// If stacks can't be parsed (e.g. under TinyGo), there's nothing to
+	// record; Find/VerifyNone will separately report ErrNoStacks.
+	if all, err := _stackAll(); err == nil {
+		for _, s := range all {
+			excludeIDSet[s.ID()] = true
+		}
 	}
 	return addFilter(func(s stack.Stack) bool {
 		return excludeIDSet[s.ID()]

--- a/options_test.go
+++ b/options_test.go
@@ -31,7 +31,8 @@ import (
 
 func TestOptionsFilters(t *testing.T) {
 	opts := buildOpts()
-	cur := stack.Current()
+	cur, err := stack.Current()
+	require.NoError(t, err)
 	all := getStableAll(t, cur)
 
 	// At least one of these should be the same as current, the others should be filtered out.
@@ -48,7 +49,9 @@ func TestOptionsFilters(t *testing.T) {
 	// Now the filters should find something that doesn't match a filter.
 	countUnfiltered := func() int {
 		var unmatched int
-		for _, s := range stack.All() {
+		all, err := stack.All()
+		require.NoError(t, err)
+		for _, s := range all {
 			if s.ID() == cur.ID() {
 				continue
 			}
@@ -62,13 +65,17 @@ func TestOptionsFilters(t *testing.T) {
 
 	// If we add an extra filter to ignore blockTill, it shouldn't match.
 	opts = buildOpts(IgnoreTopFunction("go.uber.org/goleak.(*blockedG).block"))
-	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", stack.All())
+	all, err = stack.All()
+	require.NoError(t, err)
+	require.Zero(t, countUnfiltered(), "blockedG should be filtered out. running: %v", all)
 
 	// If we ignore startBlockedG, that should not ignore the blockedG goroutine
 	// because startBlockedG should be the "created by" function in the stack.
 	opts = buildOpts(IgnoreAnyFunction("go.uber.org/goleak.startBlockedG"))
+	all, err = stack.All()
+	require.NoError(t, err)
 	require.Equal(t, 1, countUnfiltered(),
-		"startBlockedG should not be filtered out. running: %v", stack.All())
+		"startBlockedG should not be filtered out. running: %v", all)
 }
 
 func TestOptionsIgnoreCreatedBy(t *testing.T) {
@@ -78,10 +85,13 @@ func TestOptionsIgnoreCreatedBy(t *testing.T) {
 	}()
 	defer close(stopCh)
 
-	cur := stack.Current()
+	cur, err := stack.Current()
+	require.NoError(t, err)
 	opts := buildOpts(IgnoreCreatedBy("go.uber.org/goleak.TestOptionsIgnoreCreatedBy"))
 
-	for _, s := range stack.All() {
+	all, err := stack.All()
+	require.NoError(t, err)
+	for _, s := range all {
 		if s.ID() == cur.ID() {
 			continue
 		}
@@ -95,10 +105,13 @@ func TestOptionsIgnoreCreatedBy(t *testing.T) {
 }
 
 func TestOptionsIgnoreAnyFunction(t *testing.T) {
-	cur := stack.Current()
+	cur, err := stack.Current()
+	require.NoError(t, err)
 	opts := buildOpts(IgnoreAnyFunction("go.uber.org/goleak.(*blockedG).run"))
 
-	for _, s := range stack.All() {
+	all, err := stack.All()
+	require.NoError(t, err)
+	for _, s := range all {
 		if s.ID() == cur.ID() {
 			continue
 		}
@@ -121,4 +134,19 @@ func TestOptionsRetry(t *testing.T) {
 	}
 	assert.False(t, opts.retry(51), "Attempt 51/51 should not allow retrying")
 	assert.False(t, opts.retry(52), "Attempt 52/51 should not allow retrying")
+}
+
+func TestIgnoreCurrentNoStacks(t *testing.T) {
+	// If stacks can't be parsed, IgnoreCurrent records nothing and produces a
+	// filter that excludes no goroutines (rather than panicking).
+	origAll := _stackAll
+	t.Cleanup(func() { _stackAll = origAll })
+	_stackAll = func() ([]stack.Stack, error) { return nil, stack.ErrNoStacks }
+
+	opts := buildOpts(IgnoreCurrent())
+
+	cur, err := stack.Current()
+	require.NoError(t, err)
+	require.False(t, opts.filter(cur),
+		"with no recorded goroutines, IgnoreCurrent should not filter anything")
 }

--- a/testmain.go
+++ b/testmain.go
@@ -21,9 +21,12 @@
 package goleak
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+
+	"go.uber.org/goleak/internal/stack"
 )
 
 // Variables for stubbing in unit tests.
@@ -49,6 +52,10 @@ type TestingM interface {
 //
 // This will run all tests as per normal, and if they were successful, look
 // for any goroutine leaks and fail the tests if any leaks were found.
+//
+// If goleak is unable to parse goroutine stacks (for example under TinyGo),
+// the leak check is skipped: a message is written to stderr and the exit code
+// is left unchanged.
 func VerifyTestMain(m TestingM, options ...Option) {
 	exitCode := m.Run()
 	opts := buildOpts(options...)
@@ -75,10 +82,15 @@ func VerifyTestMain(m TestingM, options ...Option) {
 
 	if run {
 		if err := Find(opts); err != nil {
-			fmt.Fprintf(_osStderr, errorMsg, err)
-			// rewrite exitCode if test passed and is set to 0.
-			if exitCode == 0 {
-				exitCode = 1
+			if errors.Is(err, stack.ErrNoStacks) {
+				// goleak can't run here (e.g. TinyGo); skip rather than fail.
+				fmt.Fprintf(_osStderr, "%v; skipping goroutine leak detection\n", err)
+			} else {
+				fmt.Fprintf(_osStderr, errorMsg, err)
+				// rewrite exitCode if test passed and is set to 0.
+				if exitCode == 0 {
+					exitCode = 1
+				}
 			}
 		}
 	}

--- a/testmain_test.go
+++ b/testmain_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.uber.org/goleak/internal/stack"
 )
 
 func init() {
@@ -88,4 +90,20 @@ func TestVerifyTestMain(t *testing.T) {
 	}))
 	assert.True(t, cleanupCalled)
 	assert.Equal(t, 3, cleanupExitcode)
+}
+
+func TestVerifyTestMainNoStacks(t *testing.T) {
+	defer clearOSStubs()
+	exitCode, stderr := osStubs()
+
+	// Simulate a runtime whose stacks can't be parsed (e.g. TinyGo).
+	origCurrent := _stackCurrent
+	defer func() { _stackCurrent = origCurrent }()
+	_stackCurrent = func() (stack.Stack, error) { return stack.Stack{}, stack.ErrNoStacks }
+
+	VerifyTestMain(dummyTestMain(0))
+	assert.Equal(t, 0, <-exitCode, "Exit code should stay 0 when stacks can't be parsed")
+	out := <-stderr
+	assert.Contains(t, out, "skipping goroutine leak detection")
+	assert.NotContains(t, out, "goleak: Errors")
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -57,7 +57,10 @@ func (bg *blockedG) unblock() {
 }
 
 func getStableAll(t *testing.T, cur stack.Stack) []stack.Stack {
-	all := stack.All()
+	all, err := stack.All()
+	if err != nil {
+		t.Fatalf("stack.All() failed: %v", err)
+	}
 
 	// There may be running goroutines that were just scheduled or finishing up
 	// from previous tests, so reduce flakiness by waiting till no other goroutines
@@ -72,7 +75,10 @@ func getStableAll(t *testing.T, cur stack.Stack) []stack.Stack {
 		}
 
 		runtime.Gosched()
-		all = stack.All()
+		all, err = stack.All()
+		if err != nil {
+			t.Fatalf("stack.All() failed: %v", err)
+		}
 	}
 
 	return all


### PR DESCRIPTION
Under runtimes such as TinyGo, runtime.Stack produces no output that goleak can parse, so stack.Current() indexed an empty slice and panicked with "index out of range". Current and All now return stack.ErrNoStacks in that case; Find propagates it, and VerifyNone/VerifyTestMain log a message and skip the check instead of crashing.

The public API is unchanged: the new (Stack, error) signatures are confined to the internal/stack package and the sentinel is internal. parseStacks still panics on malformed (non-empty) traces, so a parse failure on standard Go remains a loud goleak bug rather than a silent skip.

Also add a TinyGo CI job that runs a smoke program (internal/tinygocheck, built only under the tinygo build tag) so this path is exercised on every change. This addresses the concern raised in #72.